### PR TITLE
Fix for district heating demand, where demand remained on 2018 levels

### DIFF
--- a/genesysmod_bounds.gms
+++ b/genesysmod_bounds.gms
@@ -219,5 +219,5 @@ $endif
 
 
 loop(y,
-SpecifiedAnnualDemand(r,f,y)$(not sameas(f,'H2') and YearVal(y)>%year%) = SpecifiedAnnualDemand(r,f,y-1)*(1+SpecifiedDemandDevelopment(r,f,y)*YearlyDifferenceMultiplier(y-1))
+SpecifiedAnnualDemand(r,f,y)$(not sameas(f,'H2') and not sameas(f,'Heat_District') and YearVal(y)>%year%) = SpecifiedAnnualDemand(r,f,y-1)*(1+SpecifiedDemandDevelopment(r,f,y)*YearlyDifferenceMultiplier(y-1))
 );


### PR DESCRIPTION
# 📌 Pull Request Summary

This code line resulted in SpecifiedAnnualDemand for District Heating to remain at 2018 levels, due to SpecifiedDemandDevelopment not given for District Heating. The fix excludes District Heating from this calculation. 

## 🔗 Related Issue(s)

## 🛠️ Changes Introduced

- District Heating excluded from calculation of demand pathways (instead taking the exogenously given demands)

## 📋 Checklist

- [x] Code follows project conventions
- [ ] Tests have been added/updated (if needed)
- [ ] Documentation has been updated (if applicable)
- [ ] Relevant issues linked
- [x] Reviewers assigned
