### PR TITLE
fixed issue in handling of SpecifedDemandDevelopment

### DIFF
--- a/genesysmod_bounds.gms
+++ b/genesysmod_bounds.gms
@@ -219,5 +219,6 @@ $endif
 
 
 loop(y,
-SpecifiedAnnualDemand(r,f,y)$(SpecifiedDemandDevelopment(r,f,y)<>0 and not sameas(f,'H2') and not sameas(f,'Heat_District') and YearVal(y)>%year%) = SpecifiedAnnualDemand(r,f,y-1)*(1+SpecifiedDemandDevelopment(r,f,y)*YearlyDifferenceMultiplier(y-1))
+SpecifiedAnnualDemand(r,f,y)$(not sameas(f,'H2') and not sameas(f,'Heat_District') and YearVal(y)>%year%) =
+SpecifiedAnnualDemand(r,f,y-1)*(1+SpecifiedDemandDevelopment(r,f,y)*YearlyDifferenceMultiplier(y-1))
 );


### PR DESCRIPTION
# 📌 Pull Request Summary

fixed issue where a zero in SpecifedDemandDevelopment would cause a "blackout" of SpecifiedDemand data, as it would iterate on these zero values and turn all demands to nothing.

this is solved by removing the condition of SpecifiedDemandDevelopment being non-zero, so now it will always default to the previous year if no data is given

