### PR TITLE
Added feature - vertical integration

### DIFF
--- a/genesysmod.gms
+++ b/genesysmod.gms
@@ -33,7 +33,7 @@ $if not set emissionScenario             $setglobal emissionScenario globalLimit
 * ### settings for time series reduction
 
 $if not set timeseries_method            $setglobal timeseries_method elmod
-$if not set elmod_nthhour                $setglobal elmod_nthhour 724
+$if not set elmod_nthhour                $setglobal elmod_nthhour 244
 $if not set elmod_starthour              $setglobal elmod_starthour 8
 $if not set elmod_dunkelflaute           $setglobal elmod_dunkelflaute 0
 
@@ -42,7 +42,7 @@ $if not set elmod_dunkelflaute           $setglobal elmod_dunkelflaute 0
 $if not set switch_test_data_load        $setglobal switch_test_data_load 0
 $if not set switch_only_load_gdx         $setglobal switch_only_load_gdx 0
 
-$if not set switch_unixPath              $setglobal switch_unixPath 0
+$if not set switch_unixPath              $setglobal switch_unixPath 1
 $if not set switch_read_data_long        $setglobal switch_read_data_long 1
 $if not set switch_write_output          $setglobal switch_write_output gdx
 $if not set switch_only_write_results    $setglobal switch_only_write_results 0
@@ -92,6 +92,9 @@ $if not set set_peaking_minrun_share     $setglobal set_peaking_minrun_share 0.1
 $if not set switch_employment_calculation $setglobal switch_employment_calculation 0
 $if not set eployment_data_file          $setglobal employment_data_file Employment_v01_06_11_2019
 
+* ### settings for vertically integrated model run
+
+$if not set switch_vertical_integration  $setglobal switch_vertical_integration 0
 
 ****** end of switches / settings *********
 *******************************************
@@ -122,7 +125,12 @@ $setglobal hourly_data_file Timeseries_Europe_EnVis_Green
 $elseif %emissionPathway% == Trinity
 $setglobal data_file RegularParameters_Europe_EnVis_Trinity
 $setglobal hourly_data_file Timeseries_Europe_EnVis_Trinity
+$elseif %emissionPathway% == NECPEssentials_Sweden
+$setglobal data_file RegularParameters_Sweden_EnVis_NECPEssentials
+$setglobal hourly_data_file Timeseries_Sweden
 $endif
+
+
 
 $ifthen %model_region% == middleearth
 $setglobal data_file RegularParameters_MiddleEarth
@@ -150,7 +158,11 @@ $include genesysmod_dec.gms
 
 $offlisting
 $ifthen %switch_read_data_long% == 1
+$ifthen %switch_vertical_integration% == 1
+$include genesysmod_dataload_long_vertical_integration.gms
+$else
 $include genesysmod_dataload_long.gms
+$endIf
 $else
 $include genesysmod_dataload.gms
 $endif
@@ -222,6 +234,7 @@ solutiontype 2
 quality yes
 *barobjrng 1e+075
 tilim 1000000
+iis 0
 $offecho
 
 $onecho > gurobi.opt

--- a/genesysmod_additional_results.gms
+++ b/genesysmod_additional_results.gms
@@ -246,6 +246,10 @@ additional_production(r,'InputDemand','Heat_High_Industrial_Demand','1','Heat_Hi
 *additional_production(r,'Trade','Trade','1',f,y,l,'NetTrade','PJ','%EmissionPathway%_%sensitivity%') = - NetTrade.l(y,l,f,r) ;
 additional_production(r,'Trade','Trade','1',f,y,l,'NetTrade','TWh','%EmissionPathway%_%sensitivity%') = - NetTrade.l(y,l,f,r)* 0.2778 ;
 
+$ifThen %switch_vertical_integration% == 1
+additional_production(r,'ExogenousTrade','ExogenousTrade','1',f,y,l,'ExogenousNetTrade','TWh','%EmissionPathway%_%sensitivity%') = - ExogenousNetTrade.l(y,l,f,r)* 0.2778 ;
+$endIf
+
 additional_production(r,'Storage Losses',StorageDummies,m,f,y,l,'Use','TWh','%EmissionPathway%_%EmissionScenario%')$(OutputActivityRatio(r,StorageDummies,f,m,y)) = -(ProductionByTechnology.l(y,l,StorageDummies,f,r)*(1-OutputActivityRatio(r,StorageDummies,f,m,y)))/3.6;
 
 

--- a/genesysmod_bounds.gms
+++ b/genesysmod_bounds.gms
@@ -21,7 +21,13 @@
 *
 
 TradeCosts(r,'ETS',y,rr)$(not TradeCosts(r,'ETS',y,rr)) = 0.01;
+TradeCosts(r,'Power',y,rr)$(not TradeCosts(r,'Power',y,rr)) = 0.001;
 VariableCost(r,t,m,y)$(not VariableCost(r,t,m,y)) = 0.01;
+
+$ifthen %switch_vertical_integration% == 1
+ExogenousTradeCosts(y,'ETS',r,exr)$(not ExogenousTradeCosts(y,'ETS',r,exr)) = 0.01;
+ExogenousTradeCosts(y,'Power',r,exr)$(not ExogenousTradeCosts(y,'Power',r,exr)) = 0.001;
+$endIf
 
 *
 * ##############################################################
@@ -118,12 +124,11 @@ CapacityFactor(r,'HD_Solar_Thermal',l,y) = CapacityFactor(r,'P_PV_Utility_Avg',l
 * ####### No new capacity construction in 2015 #############
 *
 NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'Transformation')) = 0;
+NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'CHP')) = 0;
 NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'PowerSupply')) = 0;
 NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'SectorCoupling')) = 0;
 NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'StorageDummies')) = 0;
 NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'Transport')) = 0;
-NewCapacity.fx('%year%',t,r)$(TagTechnologyToSubsets(t,'CHP')) = 0;
-
 NewCapacity.up('%year%',t,r)$(TagTechnologyToSubsets(t,'Biomass')) = +INF;
 NewCapacity.up('%year%','D_Gas_Methane',r) = +INF;
 NewCapacity.up('%year%','X_SMR',r) = +INF;
@@ -153,7 +158,6 @@ DummyTechnology('Infeasibility_Power') = yes;
 DummyTechnology('Infeasibility_Mob_Passenger') = yes;
 DummyTechnology('Infeasibility_Mob_Freight') = yes;
 DummyTechnology('Infeasibility_Natural_Gas') = yes;
-DummyTechnology('Infeasibility_HD') = yes;
 TagTechnologyToSector(DummyTechnology,'Infeasibility') = 1;
 AvailabilityFactor(r,DummyTechnology,y) = 0;
 
@@ -172,7 +176,6 @@ OutputActivityRatio(REGION,'Infeasibility_Power','Power','1',y) = 1;
 OutputActivityRatio(REGION,'Infeasibility_Mob_Passenger','Mobility_Passenger','1',y) = 1 ;
 OutputActivityRatio(REGION,'Infeasibility_Mob_Freight','Mobility_Freight','1',y) = 1 ;
 OutputActivityRatio(REGION,'Infeasibility_Natural_Gas','Gas_Natural','1',y) = 1;
-OutputActivityRatio(REGION,'Infeasibility_HD','Heat_District','1',y) = 1;
 
 CapacityToActivityUnit(DummyTechnology) = 31.56;
 TotalAnnualMaxCapacity(r,DummyTechnology,y) = 999999;

--- a/genesysmod_dataload_long_vertical_integration.gms
+++ b/genesysmod_dataload_long_vertical_integration.gms
@@ -1,0 +1,399 @@
+* GENeSYS-MOD v4.0 [Global Energy System Model]  ~ August 2025    
+*
+* #############################################################
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* #############################################################
+
+
+
+$offorder
+
+Parameter
+Readin_TradeRoute(r_full,rr_full,f)
+Readin_TradeCapacity(r_full,rr_full,f,y_full)
+Readin_CommissionedTradeCapacity(r_full,rr_full,f,y_full)
+Readin_GrowthRateTradeCapacity(r_full,rr_full,f,y_full)
+Readin_TradeCapacityGrowthCosts(r_full,rr_full,f)
+Readin_ModalSplitByFuelAndModalType(r_full,f,y_full,mt)
+Readin_TotalTechnologyModelPeriodActivityUpperLimit(REGION_FULL,TECHNOLOGY)
+;
+
+* Step 1: REDONE - Now reads from combined data file
+
+$onecho >%tempdir%temp_%data_file%_sets.tmp
+se=0
+        set=Region_full            Rng=Sets!A2                         rdim=1        cdim=0
+        set=Technology            Rng=Sets!B2                         rdim=1        cdim=0
+        set=Storage               Rng=Sets!C2                         rdim=1        cdim=0
+        set=Fuel                   Rng=Sets!D2                         rdim=1        cdim=0
+        set=Mode_of_operation      Rng=Sets!E2                         rdim=1        cdim=0
+        set=Emission               Rng=Sets!F2                         rdim=1        cdim=0
+        set=ModalType              Rng=Sets!G2                         rdim=1        cdim=0
+        set=Sector                 Rng=Sets!H2                         rdim=1        cdim=0
+        set=Year                   Rng=Sets!I2                         rdim=1        cdim=0
+        set=Exogenous_region_full       Rng=Sets!L2                         rdim=1       cdim=0
+
+$offecho
+
+$ifthen %switch_unixPath% == 1
+$if exist gams_connect.inc $call "rm gams_connect.inc"
+$setglobal run_connect 1
+$call "gams genesysmod_gams_connect.gms --task=check_date --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_sets.gdx";
+$if exist gams_connect.inc $include gams_connect.inc
+$ifi %run_connect% == 0 $log "Skipping GAMS Connect: %gdxdir%%data_file%_sets.gdx is up to date."
+$ifi %switch_only_load_gdx% == 0 $ifi %run_connect% == 1 $call "gams genesysmod_gams_connect.gms --task=load_sets_vertical_integration --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_sets.gdx";
+$elseif %switch_dataload_engine% == gamsconnect
+$if exist gams_connect.inc $call "rm gams_connect.inc"
+$setglobal run_connect 1
+$call "gams genesysmod_gams_connect.gms --task=check_date --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_sets.gdx";
+$if exist gams_connect.inc $include gams_connect.inc
+$ifi %run_connect% == 0 $log "Skipping GAMS Connect: %gdxdir%%data_file%_sets.gdx is up to date."
+$ifi %switch_only_load_gdx% == 0 $ifi %run_connect% == 1 $call "gams genesysmod_gams_connect.gms --task=load_sets_vertical_integration --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_sets.gdx";
+$else
+$ifi %switch_only_load_gdx% == 0 $call "gdxxrw %inputdir%%data_file%.xlsx @%tempdir%temp_%data_file%_sets.tmp o=%gdxdir%%data_file%_sets.gdx MaxDupeErrors=99 CheckDate ";
+$endif
+$GDXin %gdxdir%%data_file%_sets.gdx
+$onUNDF
+$loadm Region_full Technology Storage Fuel
+$loadm Mode_of_operation Emission ModalType
+$loadm Sector Year
+$loadm Exogenous_region_full
+$offUNDF
+* Step 2: Read parameters from regional file  -> now includes World values
+
+$onecho >%tempdir%temp_%data_file%_par.tmp
+se=0
+
+        par=SpecifiedAnnualDemand    Rng=Par_SpecifiedAnnualDemand!A2                   rdim=3  cdim=0
+        par=SpecifiedDemandDevelopment    Rng=Par_SpecifiedDemandDevelopment!A2         rdim=3  cdim=0
+        par=SpecifiedDemandProfile   Rng=Par_SpecifiedDemandProfile!A2                  rdim=4  cdim=0
+        par=ReserveMarginTagFuel     Rng=Par_ReserveMarginTagFuel!A2                    rdim=3  cdim=0
+
+        par=EmissionsPenalty         Rng=Par_EmissionsPenalty!A2                         rdim=3  cdim=0
+        par=EmissionsPenaltyTagTechnology         Rng=Par_EmissionPenaltyTagTech!A2                         rdim=4  cdim=0
+        par=ReserveMargin            Rng=Par_ReserveMargin!A2                            rdim=2  cdim=0
+        par=AnnualExogenousEmission  Rng=Par_AnnualExogenousEmission!A2                  rdim=3  cdim=0
+        par=RegionalAnnualEmissionLimit      Rng=Par_RegionalAnnualEmissionLimit!A2                      rdim=3  cdim=0
+        par=AnnualEmissionLimit      Rng=Par_AnnualEmissionLimit!A2                      rdim=2  cdim=0
+        par=Readin_TradeRoute    Rng=Par_TradeRoute!A2                          rdim=3  cdim=0
+        par=TradeCostFactor               Rng=Par_TradeCostFactor!A2                     rdim=2  cdim=0
+        par=Readin_TradeCapacity  Rng=Par_TradeCapacity!A2            rdim=4  cdim=0
+        par=Readin_CommissionedTradeCapacity  Rng=Par_CommissionedTradeCapacity!A2            rdim=4  cdim=0
+        par=REMinProductionTarget  Rng=Par_REMinProductionTarget!A2                      rdim=3  cdim=0
+        par=SelfSufficiency  Rng=Par_SelfSufficiency!A2                                  rdim=3  cdim=0
+        par=ProductionGrowthLimit  Rng=Par_ProductionGrowthLimit!A2                                  rdim=2  cdim=0 
+
+        par=Readin_GrowthRateTradeCapacity         Rng=Par_GrowthRateTradeCapacity!A2  rdim=4 cdim=0
+        par=Readin_TradeCapacityGrowthCosts        Rng=Par_TradeCapacityGrowthCosts!A2  rdim=3 cdim=0
+        par=CapacityToActivityUnit   Rng=Par_CapacityToActivityUnit!A2   rdim=1        cdim=0
+
+        par=InputActivityRatio       Rng=Par_InputActivityRatio!A2                       rdim=5        cdim=0
+        par=OutputActivityRatio      Rng=Par_OutputActivityRatio!A2                      rdim=5        cdim=0
+        par=FixedCost                Rng=Par_FixedCost!A2                                rdim=3        cdim=0
+        par=CapitalCost              Rng=Par_CapitalCost!A2                              rdim=3        cdim=0
+        par=VariableCost             Rng=Par_VariableCost!A2                             rdim=4        cdim=0
+        par=ResidualCapacity         Rng=Par_ResidualCapacity!A2                         rdim=3        cdim=0
+        par=AvailabilityFactor       Rng=Par_AvailabilityFactor!A2                       rdim=3        cdim=0
+        par=CapacityFactor           Rng=Par_CapacityFactor!A2                           rdim=4        cdim=0
+        par=EmissionActivityRatio    Rng=Par_EmissionActivityRatio!A2                    rdim=5        cdim=0
+        par=EmissionContentPerFuel   Rng=Par_EmissionContentPerFuel!A2                   rdim=2        cdim=0
+        par=OperationalLife          Rng=Par_OperationalLife!A2                          rdim=1        cdim=0
+        par=TotalAnnualMaxCapacity   Rng=Par_TotalAnnualMaxCapacity!A2                   rdim=3        cdim=0
+        par=TotalAnnualMinCapacity   Rng=Par_TotalAnnualMinCapacity!A2                   rdim=3        cdim=0
+        par=NewCapacityExpansionStop   Rng=Par_NewCapacityExpansionStop!A2               rdim=2        cdim=0
+        par=Readin_TotalTechnologyModelPeriodActivityUpperLimit   Rng=Par_ModelPeriodActivityMaxLimit!A2         rdim=2        cdim=0
+
+        par=TotalTechnologyAnnualActivityUpperLimit   Rng=Par_TotalAnnualMaxActivity!A2                   rdim=3        cdim=0
+        par=TotalTechnologyAnnualActivityLowerLimit   Rng=Par_TotalAnnualMinActivity!A2                   rdim=3        cdim=0
+
+        par=ReserveMarginTagTechnology  Rng=Par_ReserveMarginTagTechnology!A2            rdim=3        cdim=0
+
+        par=RegionalCCSLimit             Rng=Par_RegionalCCSLimit!A2               rdim=1        cdim=0
+
+        par=TechnologyToStorage   Rng=Par_TechnologyToStorage!A2                         rdim=4        cdim=0
+        par=TechnologyFromStorage Rng=Par_TechnologyFromStorage!A2                       rdim=4        cdim=0
+        par=StorageLevelStart     Rng=Par_StorageLevelStart!A2                           rdim=2        cdim=0
+        par=MinStorageCharge      Rng=Par_MinStorageCharge!A2                            rdim=3        cdim=0
+        par=OperationalLifeStorage Rng=Par_OperationalLifeStorage!A2                     rdim=1        cdim=0
+        par=CapitalCostStorage    Rng=Par_CapitalCostStorage!A2                          rdim=3        cdim=0
+        par=ResidualStorageCapacity Rng=Par_ResidualStorageCapacity!A2                   rdim=3        cdim=0
+
+        par=Readin_ModalSplitByFuelAndModalType   Rng=Par_ModalSplitByFuel!A2                    rdim=4        cdim=0
+        par=TagTechnologyToModalType       Rng=Par_TagTechnologyToModalType!A2                       rdim=3        cdim=0
+
+        par=BaseYearProduction   Rng=Par_BaseYearProduction!A2                   rdim=3        cdim=0
+        par=RegionalBaseYearProduction   Rng=Par_RegionalBaseYearProduction!A2                    rdim=4        cdim=0
+
+        par=TagTechnologyToSector       Rng=Par_TagTechnologyToSector!A2                       rdim=2        cdim=0
+        par=AnnualSectoralEmissionLimit      Rng=Par_AnnualSectoralEmissionLimit!A2                      rdim=3  cdim=0
+        par=TagDemandFuelToSector       Rng=Par_TagDemandFuelToSector!A2                       rdim=2        cdim=0
+        par=TagElectricTechnology       Rng=Par_TagElectricTechnology!A2                       rdim=1        cdim=0
+
+        par=TagTechnologyToSubsets                Rng=Par_TagTechnologyToSubsets!A2                rdim=2        cdim=0
+        par=TagModalTypeToModalGroups                Rng=Par_TagModalTypeToModalGroups!A2          rdim=2        cdim=0
+        par=TagFuelToSubsets                      Rng=Par_TagFuelToSubsets!A2                      rdim=2        cdim=0
+        par=StorageE2PRatio                      Rng=Par_StorageE2PRatio!A2                      rdim=1          cdim=0
+        par=TagCanFuelBeTraded                      Rng=Par_TagCanFuelBeTraded!A2                      rdim=1          cdim=0
+
+        par=ModelPeriodEmissionLimit       Rng=Par_ModelPeriodEmissionLimit!A2                    rdim=1        cdim=0
+        par=RegionalModelPeriodEmissionLimit       Rng=Par_RegionalModelPeriodEmission!A2         rdim=2        cdim=0
+        par=ModelPeriodExogenousEmission       Rng=Par_ModelPeriodExogenousEmissio!A2            rdim=2        cdim=0
+        
+        par=AnnualMinNewCapacity         Rng=Par_AnnualMinNewCapacity!A2                         rdim=3        cdim=0
+        par=AnnualMaxNewCapacity         Rng=Par_AnnualMaxNewCapacity!A2                         rdim=3        cdim=0
+        
+        par=DistrictHeatDemand         Rng=Par_DistrictHeatDemand!A2                         rdim=2        cdim=0
+        par=DistrictHeatSplit         Rng=Par_DistrictHeatSplit!A2                         rdim=3        cdim=0
+        
+        par=ExogenousDemand                     Rng=Par_ExogenousDemand!A2                     rdim=4      cdim=0
+        par=ExogenousProduction                 Rng=Par_ExogenousProduction!A2                 rdim=4      cdim=0
+        par=ExogenousTradeRoute                 Rng=Par_ExogenousTradeRoute!A2                 rdim=3      cdim=0
+        par=ResidualExogenousTradeCapacity      Rng=Par_ResidualExoTradeCapacity!A2            rdim=4      cdim=0
+        par=CommissionedExogenousTradeCapacity  Rng=Par_CommissionedExoTradeCap!A2             rdim=4      cdim=0
+        par=GrowthRateExogenousTradeCapacity    Rng=Par_GrowthRateExoTradeCapacity!A2          rdim=4      cdim=0
+        par=ExogenousTradeCapacityGrowthCosts   Rng=Par_ExoTradeCapacityGrowthCosts!A2         rdim=3      cdim=0
+$offecho
+
+$ifthen %switch_unixPath% == 1
+$setglobal run_connect 1
+$call "gams genesysmod_gams_connect.gms --task=check_date --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_par.gdx";
+$if exist gams_connect.inc $include gams_connect.inc
+$ifi %run_connect% == 0 $log "Skipping GAMS Connect: %gdxdir%%data_file%_par.gdx is up to date."
+$ifi %switch_only_load_gdx%==0 $ifi %run_connect% == 1 $call "gams genesysmod_gams_connect.gms --task=load_params_vertical_integration --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_par.gdx";  
+$elseif %switch_dataload_engine% == gamsconnect
+$setglobal run_connect 1
+$call "gams genesysmod_gams_connect.gms --task=check_date --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_par.gdx";
+$if exist gams_connect.inc $include gams_connect.inc
+$ifi %run_connect% == 0 $log "Skipping GAMS Connect: %gdxdir%%data_file%_par.gdx is up to date."
+$ifi %switch_only_load_gdx%==0 $ifi %run_connect% == 1 $call "gams genesysmod_gams_connect.gms --task=load_params_vertical_integration --in_file=%inputdir%%data_file%.xlsx --out_file=%gdxdir%%data_file%_par.gdx";
+$else
+$ifi %switch_only_load_gdx%==0 $call "gdxxrw %inputdir%%data_file%.xlsx @%tempdir%temp_%data_file%_par.tmp o=%gdxdir%%data_file%_par.gdx MaxDupeErrors=99 CheckDate ";
+$endif
+
+$GDXin %gdxdir%%data_file%_par.gdx
+$onUNDF
+$loadm
+$loadm SpecifiedAnnualDemand ReserveMarginTagFuel
+$loadm EmissionsPenalty ReserveMargin AnnualExogenousEmission AnnualEmissionLimit RegionalAnnualEmissionLimit ReserveMarginTagTechnology
+$loadm ReserveMarginTagFuel Readin_TradeRoute Readin_TradeCapacity Readin_GrowthRateTradeCapacity Readin_TradeCapacityGrowthCosts TradeCostFactor Readin_CommissionedTradeCapacity
+$loadm InputActivityRatio OutputActivityRatio FixedCost CapitalCost VariableCost ResidualCapacity   EmissionsPenaltyTagTechnology
+$loadm AvailabilityFactor CapacityFactor EmissionActivityRatio OperationalLife TotalAnnualMaxCapacity TotalAnnualMinCapacity EmissionContentPerFuel
+$loadm TotalTechnologyAnnualActivityLowerLimit TotalTechnologyAnnualActivityUpperLimit ModelPeriodExogenousEmission
+$loadm Readin_TotalTechnologyModelPeriodActivityUpperLimit REMinProductionTarget ProductionGrowthLimit
+$loadm TechnologyToStorage TechnologyFromStorage StorageLevelStart MinStorageCharge
+$loadm CapitalCostStorage OperationalLifeStorage SpecifiedDemandDevelopment
+$loadm ResidualStorageCapacity CapacityToActivityUnit SelfSufficiency NewCapacityExpansionStop
+$loadm Readin_ModalSplitByFuelAndModalType TagTechnologyToModalType BaseYearProduction RegionalBaseYearProduction
+$loadm TagTechnologyToSector AnnualSectoralEmissionLimit TagCanFuelBeTraded AnnualMinNewCapacity AnnualMaxNewCapacity
+$loadm RegionalCCSLimit TagDemandFuelToSector TagElectricTechnology  TagModalTypeToModalGroups
+$loadm TagTechnologyToSubsets TagFuelToSubsets StorageE2PRatio  ModelPeriodEmissionLimit  RegionalModelPeriodEmissionLimit
+$loadm DistrictHeatDemand DistrictHeatSplit
+$loadm ExogenousDemand ExogenousProduction ExogenousTradeRoute
+$loadm ResidualExogenousTradeCapacity CommissionedExogenousTradeCapacity GrowthRateExogenousTradeCapacity ExogenousTradeCapacityGrowthCosts
+$offUNDF
+
+*
+* ####### Step 3: Set regional values, if only value given for base-region #############
+*
+
+*CapitalCost(REGION_FULL,TECHNOLOGY,y)$(CapitalCost(REGION_FULL,TECHNOLOGY,y) = 0) = CapitalCost('%data_base_region%',TECHNOLOGY,y);
+*VariableCost(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,y)$(VariableCost(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,y) = 0) = VariableCost('%data_base_region%',TECHNOLOGY,MODE_OF_OPERATION,y);
+*FixedCost(REGION_FULL,TECHNOLOGY,y)$(FixedCost(REGION_FULL,TECHNOLOGY,y) = 0) = FixedCost('%data_base_region%',TECHNOLOGY,y);
+*AvailabilityFactor(REGION_FULL,TECHNOLOGY,y)$(AvailabilityFactor(REGION_FULL,TECHNOLOGY,y) = 0) = AvailabilityFactor('%data_base_region%',TECHNOLOGY,y);
+*InputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y)$(InputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y) = 0) = InputActivityRatio('%data_base_region%',TECHNOLOGY,FUEL,MODE_OF_OPERATION,y);
+*OutputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y)$(OutputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y) = 0) = OutputActivityRatio('%data_base_region%',TECHNOLOGY,FUEL,MODE_OF_OPERATION,y);
+*EmissionsPenaltyTagTechnology(REGION_FULL,t,e,y)$(EmissionsPenaltyTagTechnology(REGION_FULL,t,e,y) = 0) = EmissionsPenaltyTagTechnology('%data_base_region%',t,e,y);
+*
+*ReserveMarginTagTechnology(REGION_FULL,TECHNOLOGY,y)$(ReserveMarginTagTechnology(REGION_FULL,TECHNOLOGY,y) = 0) = ReserveMarginTagTechnology('%data_base_region%',TECHNOLOGY,y);
+*EmissionActivityRatio(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR)$(EmissionActivityRatio(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR)=0) =  EmissionActivityRatio('%data_base_region%',TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR);
+*
+*EmissionsPenalty(REGION_FULL,e,y)$(EmissionsPenalty(REGION_FULL,e,y) <> EmissionsPenalty('%data_base_region%',e,y)) = EmissionsPenalty('%data_base_region%',e,y);
+*
+*SpecifiedDemandDevelopment(r_full,f,y)$(SpecifiedDemandDevelopment(r_full,f,y) = 0) = SpecifiedDemandDevelopment('%data_base_region%',f,y);
+*RegionalModelPeriodEmissionLimit(r_full,e)$(RegionalModelPeriodEmissionLimit(r_full,e) = 0) = RegionalModelPeriodEmissionLimit('%data_base_region%',e);
+*ModelPeriodExogenousEmission(r_full,e)$(ModelPeriodExogenousEmission(r_full,e) = 0) = ModelPeriodExogenousEmission('%data_base_region%',e);
+*
+**
+** ####### Step 4: Set values, if no regional data available #############
+**
+*
+*CapitalCost(REGION_FULL,TECHNOLOGY,y)$(CapitalCost(REGION_FULL,TECHNOLOGY,y) = 0) = CapitalCost('World',TECHNOLOGY,y);
+*VariableCost(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,y)$(VariableCost(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,y) = 0) = VariableCost('World',TECHNOLOGY,MODE_OF_OPERATION,y);
+*FixedCost(REGION_FULL,TECHNOLOGY,y)$(FixedCost(REGION_FULL,TECHNOLOGY,y) = 0) = FixedCost('World',TECHNOLOGY,y);
+*AvailabilityFactor(REGION_FULL,TECHNOLOGY,y)$(AvailabilityFactor(REGION_FULL,TECHNOLOGY,y) = 0) = AvailabilityFactor('World',TECHNOLOGY,y);
+*InputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y)$(InputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y) = 0) = InputActivityRatio('World',TECHNOLOGY,FUEL,MODE_OF_OPERATION,y);
+*OutputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y)$(OutputActivityRatio(REGION_FULL,TECHNOLOGY,FUEL,MODE_OF_OPERATION,y) = 0) = OutputActivityRatio('World',TECHNOLOGY,FUEL,MODE_OF_OPERATION,y);
+*EmissionsPenaltyTagTechnology(REGION_FULL,t,e,y)$(EmissionsPenaltyTagTechnology(REGION_FULL,t,e,y) = 0) = EmissionsPenaltyTagTechnology('World',t,e,y);
+*
+*ReserveMarginTagTechnology(REGION_FULL,TECHNOLOGY,y)$(ReserveMarginTagTechnology(REGION_FULL,TECHNOLOGY,y) = 0) = ReserveMarginTagTechnology('World',TECHNOLOGY,y);
+*EmissionActivityRatio(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR)$(EmissionActivityRatio(REGION_FULL,TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR)=0) =  EmissionActivityRatio('World',TECHNOLOGY,MODE_OF_OPERATION,EMISSION,YEAR);
+*
+*ReserveMarginTagFuel(r_full,f,y)$(ReserveMarginTagFuel(r_full,f,y)=0) =  ReserveMarginTagFuel('World',f,y);
+*ReserveMargin(r_full,y)$(ReserveMargin(r_full,y)=0) = ReserveMargin('World',y);
+*ReserveMarginTagTechnology(r_full,t,y)$(ReserveMarginTagTechnology(r_full,t,y)=0) = ReserveMarginTagTechnology('World',t,y);
+*MinStorageCharge(r_full,s,y)$(MinStorageCharge(r_full,s,y)=0) = MinStorageCharge('World',s,y);
+*CapitalCostStorage(r_full,s,y)$(CapitalCostStorage(r_full,s,y)=0) = CapitalCostStorage('World',s,y);
+*
+*RegionalAnnualEmissionLimit(r_full,e,y)$(RegionalAnnualEmissionLimit(r_full,e,y) = 0) = RegionalAnnualEmissionLimit('World',e,y);
+*RegionalModelPeriodEmissionLimit(r_full,e)$(RegionalModelPeriodEmissionLimit(r_full,e) = 0) = RegionalModelPeriodEmissionLimit('World',e);
+*ModelPeriodExogenousEmission(r_full,e)$(ModelPeriodExogenousEmission(r_full,e) = 0) = ModelPeriodExogenousEmission('World',e);
+*TotalAnnualMaxCapacity(r_full,t,y)$(TotalAnnualMaxCapacity(r_full,t,y) = 0) = TotalAnnualMaxCapacity('World',t,y);
+*
+*SpecifiedDemandDevelopment(r_full,f,y)$(SpecifiedDemandDevelopment(r_full,f,y) = 0) = SpecifiedDemandDevelopment('World',f,y);
+
+StartYear = %year% ;
+
+$ifthen %switch_all_regions% == 1
+REGION(REGION_FULL) = yes;
+REGION('World') = no;
+$if set exclude_region1 REGION('%exclude_region1%') = no;
+$if set exclude_region2 REGION('%exclude_region2%') = no;
+$if set exclude_region3 REGION('%exclude_region3%') = no;
+$else
+REGION(REGION_FULL)$(ord(REGION_FULL) < 5) = yes;
+REGION('World') = no;
+$endif
+
+$ifthen %switch_aggregate_region% == 1
+
+$onmulti
+Set REGION_FULL / %model_region% /;
+$offmulti
+REGION(REGION_FULL) = yes;
+REGION('%model_region%') = no;
+REGION('World') = no;
+$endif
+
+*
+* ####### Updating order of dimensions, so that long format file works #############
+*
+
+ModalSplitByFuelAndModalType(r,f,mt,y) = Readin_ModalSplitByFuelAndModalType(r,f,y,mt);
+ModalSplitByFuelAndModalType(r_full,f,mt,y)$(ModalSplitByFuelAndModalType(r_full,f,mt,y) = 0) = ModalSplitByFuelAndModalType('World',f,mt,y);
+
+TradeRoute(r,f,y,rr) = Readin_TradeRoute(r,rr,f);
+TradeCapacity(r,f,y,rr) = Readin_TradeCapacity(r,rr,f,y);
+TradeCosts(r,f,y,rr) = TradeCostFactor(f,y)*TradeRoute(r,f,y,rr);
+CommissionedTradeCapacity(r,f,y,rr) = Readin_CommissionedTradeCapacity(r,rr,f,y);
+
+GrowthRateTradeCapacity(r,f,y,rr) = Readin_GrowthRateTradeCapacity(r,rr,f,y);
+TradeCapacityGrowthCosts(r,f,rr) = Readin_TradeCapacityGrowthCosts(r,rr,f);
+
+*
+* ####### Assigning TradeRoutes depending on initialized Regions and Year #############
+*
+GrowthRateTradeCapacity(r,f,y,rr)$(GrowthRateTradeCapacity(r,f,y,rr) = 0) = GrowthRateTradeCapacity(r,f,'%year%',rr);
+
+TradeLossFactor('Power',y) = 0.00003;
+TradeLossBetweenRegions(r,f,y,rr) = TradeLossFactor(f,y)*TradeRoute(r,f,y,rr);
+
+*
+* ####### Exogenous trade #############
+*
+EXOGENOUS_REGION(EXOGENOUS_REGION_FULL) = yes;
+ExogenousTradeLossBetweenRegions(y,f,r,exr) = TradeLossFactor(f,y)*ExogenousTradeRoute(r,exr,f);
+ExogenousTradeCosts(y,f,r,exr) = TradeCostFactor(f,y)*ExogenousTradeRoute(r,exr,f);
+
+*
+* ######### YearValue assignment #############
+*
+parameter YearVal(y_full);
+YearVal(y) = y.val ;
+
+*
+* ####### Load from hourly Data #############
+*
+$include genesysmod_timeseries_reduction.gms
+
+
+*
+* ####### Ramping #############
+*
+$ifthen %switch_ramping% == 1
+
+$onecho >%tempdir%temp_%data_file%_par2.tmp
+se=0
+        par=RampingUpFactor                Rng=Par_RampingUpFactor!A2                      rdim=2        cdim=0
+        par=RampingDownFactor              Rng=Par_RampingDownFactor!A2                    rdim=2        cdim=0
+        par=ProductionChangeCost           Rng=Par_ProductionChangeCost!A2                 rdim=2        cdim=0
+
+
+$offecho
+
+$ifi %switch_only_load_gdx%==0 $call "gdxxrw %inputdir%%data_file%.xlsx @%tempdir%temp_%data_file%_par2.tmp o=%gdxdir%%data_file%_par2.gdx MaxDupeErrors=99 CheckDate ";
+$GDXin %gdxdir%%data_file%_par2.gdx
+$onUNDF
+$loadm RampingUpFactor RampingDownFactor
+$loadm ProductionChangeCost
+$offUNDF
+
+
+MinActiveProductionPerTimeslice(y,l,'Power','RES_Hydro_Large',R_FULL) = 0.1;
+MinActiveProductionPerTimeslice(y,l,'Power','RES_Hydro_Small',R_FULL) = 0.05;
+$endif
+
+
+
+*
+* ########## Dataload of Employment Excel ##########
+*
+$ifthen %switch_employment_calculation% == 1
+
+$onecho >%tempdir%temp_%employment_data_file%.tmp
+se=0
+        dset=Technology              Rng=Sets!A2                         rdim=1        cdim=0
+        set=Year                     Rng=Sets!B2                         rdim=1        cdim=0
+        set=Region                   Rng=Sets!C2                         rdim=1        cdim=0
+
+
+        par=EFactorConstruction      Rng=Par_EFactorConstruction!A5                rdim=1        cdim=1
+        par=EFactorOM                Rng=Par_EFactorOM!A5                          rdim=1        cdim=1
+        par=EFactorManufacturing     Rng=Par_EFactorManufacturing!A5               rdim=1        cdim=1
+        par=EFactorFuelSupply        Rng=Par_EFactorFuelSupply!A5                  rdim=1        cdim=1
+        par=EFactorCoalJobs          Rng=Par_EFactorCoalJobs!A5                    rdim=1        cdim=1
+        par=CoalSupply               Rng=Par_CoalSupply!A5                    rdim=1        cdim=1
+        par=CoalDigging              Rng=Par_CoalDigging!A5                    rdim=3        cdim=1
+        par=RegionalAdjustmentFactor          Rng=Par_RegionalAdjustmentFactor!A5                    rdim=1        cdim=1
+        par=LocalManufacturingFactor          Rng=Par_LocalManufacturingFactor!A5                    rdim=1        cdim=1
+        par=DeclineRate                       Rng=Par_DeclineRate!A5                                 rdim=1        cdim=1
+
+
+
+
+$offecho
+
+$ifi %switch_only_load_gdx%==0 $call "gdxxrw %inputdir%%employment_data_file%.xlsx @%tempdir%temp_%employment_data_file%.tmp o=%gdxdir%%employment_data_file%.gdx MaxDupeErrors=999 ";
+$GDXin %gdxdir%%employment_data_file%.gdx
+$onUNDF
+$loadm Region
+$loadm EFactorConstruction
+$loadm EFactorOM
+$loadm EFactorManufacturing
+$loadm EFactorFuelSupply
+$loadm EFactorCoalJobs
+$loadm CoalSupply
+$loadm CoalDigging
+$loadm RegionalAdjustmentFactor
+$loadm LocalManufacturingFactor
+$loadm DeclineRate
+
+$offUNDF
+$endif
+
+
+
+
+
+

--- a/genesysmod_dec.gms
+++ b/genesysmod_dec.gms
@@ -33,7 +33,7 @@ set REGION_FULL All regions included in the input data;
 alias (REGION_FULL,r_full,rr_full);
 
 set REGION(REGION_FULL) Subset of regions for which computation should actually happen;
-alias (REGION,r,rr)
+alias (REGION,r,rr);
 
 set TECHNOLOGY List of all available technologies
                /Infeasibility_Power,
@@ -42,7 +42,6 @@ set TECHNOLOGY List of all available technologies
                 Infeasibility_HMI,
                 Infeasibility_HHI,
                 Infeasibility_HRI,
-                Infeasibility_HD,
                 Infeasibility_Mob_Passenger,
                 Infeasibility_Mob_Freight,
                 Infeasibility_Natural_Gas /;
@@ -63,6 +62,14 @@ alias (s,STORAGE);
 
 set MODALTYPE List of all modal types for transport;
 alias (mt,MODALTYPE);
+
+$ifthen %switch_vertical_integration% == 1
+set EXOGENOUS_REGION_FULL All exogenous regions included in the input data but should not be modelled as regions;
+alias (EXOGENOUS_REGION_FULL,exr_full);
+
+set EXOGENOUS_REGION(EXOGENOUS_REGION_FULL) Subset of exogenous regions for which computation should actually happen;
+alias (EXOGENOUS_REGION,exr);
+$endIf
 
 *
 * ####################
@@ -219,6 +226,26 @@ parameter TagTechnologyToModalType(TECHNOLOGY,MODE_OF_OPERATION,MODALTYPE);
 parameter TagModalTypeToModalGroups(MODALTYPE,*);
 
 parameter ProductionGrowthLimit(FUEL,YEAR_FULL);
+
+*
+* ######### Exogenous Trade #############
+*
+$ifThen %switch_vertical_integration% == 1
+parameter ExogenousDemand(YEAR_FULL,TIMESLICE_FULL,FUEL,EXOGENOUS_REGION_FULL) The total value of export of model regions to exogenous region; 
+parameter ExogenousProduction(YEAR_FULL,TIMESLICE_FULL,FUEL,EXOGENOUS_REGION_FULL) The total value of import of model regions from exogenous region;
+
+parameter ExogenousTradeRoute(REGION_FULL,EXOGENOUS_REGION_FULL,FUEL) The length of possible trade routes between model regions and exogenous regions;
+
+Parameter ResidualExogenousTradeCapacity(REGION_FULL,EXOGENOUS_REGION_FULL,FUEL,YEAR_FULL) The trade capacity that already existed between model regions and exogenous regions for the bas year before supermodel run;
+Parameter CommissionedExogenousTradeCapacity(REGION_FULL,EXOGENOUS_REGION_FULL,FUEL,YEAR_FULL) The trade capacity between model regions and exogenous regions which has in reality been commissioned which the model does not need to account cost for;
+
+Parameter GrowthRateExogenousTradeCapacity(REGION_FULL,EXOGENOUS_REGION_FULL,FUEL,YEAR_FULL) The growth rate factor for the exogenous trade capacity;
+parameter ExogenousTradeCapacityGrowthCosts(REGION_FULL,EXOGENOUS_REGION_FULL,FUEL) Cost of increasing trade capacity between model regions and exogenous regions; 
+
+parameter ExogenousTradeCosts(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL) Cost for trading fuels without trade capacity to exogenous regions;
+
+parameter ExogenousTradeLossBetweenRegions(y_full,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+$endIf
 
 * #####################
 * # Model Variables #
@@ -427,4 +454,24 @@ parameter CoalJobs;
 parameter output_energyjobs;
 $endif
 
+*
+* ######### Exogenous Trade #############
+*
+free variable AllDiscountedExogenousTradeCosts Sum of exogenous trade costs for capacity and flows;
 
+$ifThen %switch_vertical_integration% == 1
+positive variable ExogenousExport(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL) The export a modelled region does to a region outside system boundaries;
+positive variable ExogenousImport(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL) The import a modelled region does to a region outside system boundaries;
+
+Positive Variable TotalExogenousTradeCapacity(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL) The total trade capacity existing between model regions and exogenous regions;
+Positive Variable NewExogenousTradeCapacity(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL) The new trade capacity between model regions and exogenous regions;
+
+free variable ExogenousNetTrade(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL);
+free variable ExogenousNetTradeAnnual(YEAR_FULL,FUEL,REGION_FULL);
+
+positive variable NewExogenousTradeCapacityCosts(YEAR_FULL, FUEL, REGION_FULL, EXOGENOUS_REGION_FULL) The cost of building new trade capacity to exogenous regions;
+positive variable DiscountedNewExogenousTradeCapacityCosts(YEAR_FULL, FUEL, REGION_FULL, EXOGENOUS_REGION_FULL) Discounted cost for building trade capacity;
+
+free variable AnnualTotalExogenousTradeCosts(YEAR_FULL,REGION_FULL) Annual cost of trading fuels without trade capacity;
+free variable DiscountedAnnualTotalExogenousTradeCosts(YEAR_FULL,REGION_FULL) Discounted annual cost of trade with exogenous regions;
+$endIf

--- a/genesysmod_equ.gms
+++ b/genesysmod_equ.gms
@@ -34,6 +34,7 @@ cost.. z =e= sum((y,r), TotalDiscountedCost(y,r))
 + sum((y,r,f,t),BaseYearBounds_TooLow(y,r,t,f)*9999)
 + sum((r,y),heatingslack(y,r)*9999)
 - sum((y,r),DiscountedSalvageValueTransmission(y,r))
++ AllDiscountedExogenousTradeCosts
 ;
 
 * #########################
@@ -240,11 +241,21 @@ Import.fx(y,l,f,r,rr)$(TradeRoute(r,f,y,rr) = 0 or TagCanFuelBeTraded(f) = 0) = 
 Export.fx(y,l,f,rr,r)$(TradeRoute(r,f,y,rr) = 0 or TagCanFuelBeTraded(f) = 0) = 0;
 NetTrade.fx(y,l,f,r)$(sum(rr,TradeRoute(r,f,y,rr)) = 0 or TagCanFuelBeTraded(f) = 0) = 0;
 
+$ifthen %switch_vertical_integration% == 0
 equation EB2_EnergyBalanceEachTS(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL);
 EB2_EnergyBalanceEachTS(y,l,f,r)$(TagTimeIndependentFuel(y,f,r) = 0).. sum((t,m)$(OutputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*OutputActivityRatio(r,t,f,m,y))*YearSplit(l,y) =e= Demand(y,l,f,r) + sum((t,m)$(InputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*InputActivityRatio(r,t,f,m,y)*TimeDepEfficiency(r,t,l,y))*YearSplit(l,y) + NetTrade(y,l,f,r);
 
 equation EB3_EnergyBalanceEachYear(YEAR_FULL,FUEL,REGION_FULL);
 EB3_EnergyBalanceEachYear(y,f,r)$(TagTimeIndependentFuel(y,f,r)).. sum((l,t,m)$(OutputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*OutputActivityRatio(r,t,f,m,y)*YearSplit(l,y)) =g= sum((l,t,m)$(InputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*InputActivityRatio(r,t,f,m,y)*YearSplit(l,y)*TimeDepEfficiency(r,t,l,y)) + NetTradeAnnual(y,f,r);
+$endIf
+$ifthen %switch_vertical_integration% == 1
+equation EB2_EnergyBalanceEachTS(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL);
+EB2_EnergyBalanceEachTS(y,l,f,r)$(TagTimeIndependentFuel(y,f,r) = 0).. sum((t,m)$(OutputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*OutputActivityRatio(r,t,f,m,y))*YearSplit(l,y) =e= Demand(y,l,f,r) + sum((t,m)$(InputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*InputActivityRatio(r,t,f,m,y)*TimeDepEfficiency(r,t,l,y))*YearSplit(l,y) + NetTrade(y,l,f,r) + ExogenousNetTrade(y,l,f,r);
+
+equation EB3_EnergyBalanceEachYear(YEAR_FULL,FUEL,REGION_FULL);
+EB3_EnergyBalanceEachYear(y,f,r)$(TagTimeIndependentFuel(y,f,r)).. sum((l,t,m)$(OutputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*OutputActivityRatio(r,t,f,m,y)*YearSplit(l,y)) =g= sum((l,t,m)$(InputActivityRatio(r,t,f,m,y) <> 0), RateOfActivity(y,l,t,m,r)*InputActivityRatio(r,t,f,m,y)*YearSplit(l,y)*TimeDepEfficiency(r,t,l,y)) + NetTradeAnnual(y,f,r) + ExogenousNetTradeAnnual(y,f,r);
+$endIf
+
 
 equation EB4_NetTradeBalance(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL);
 EB4_NetTradeBalance(y,l,f,r)$(sum(rr,TradeRoute(r,f,y,rr)) and TagCanFuelBeTraded(f)).. sum(rr$(TradeRoute(r,f,y,rr)), Export(y,l,f,r,rr)*(1+TradeLossBetweenRegions(r,f,y,rr)) - Import(y,l,f,r,rr)) =e= NetTrade(y,l,f,r);
@@ -298,8 +309,6 @@ equation TrC7_TradeCapacityLimitNonPower(YEAR_FULL,FUEL,REGION_FULL,rr_full);
 TrC7_TradeCapacityLimitNonPower(y,f,r,rr)$(TradeCapacityGrowthCosts(r,f,rr) and not sameas(f,'Power')).. sum(l,Import(y,l,f,rr,r)) =l= TotalTradeCapacity(y,f,r,rr);
 
 
-
-
 equation TrPl1aa_TradeCapacityPipelinesLines(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,rr_full);
 TrPl1aa_TradeCapacityPipelinesLines(y,l,r,rr).. Import(y,l,'H2',rr,r) =l= TotalTradeCapacity(y,'H2',r,rr)*YearSplit(l,y);
 
@@ -345,11 +354,19 @@ $endif.equ_hydrogen_tradecapacity
 * ######## Gas-specific import restrictions over the year
 *
 
-equation TrPA2a_FlatH2Imports(y_full,l_full,r_full);
-TrPA2a_FlatH2Imports(y,l,r)..   RateOfActivity(y,l,'Z_Import_H2','1',r)  =l= sum(ll,RateOfActivity(y,ll,'Z_Import_H2','1',r))*YearSplit(l,y)*1.05;
+*equation TrPA2a_FlatH2Imports(y_full,l_full,r_full);
+*TrPA2a_FlatH2Imports(y,l,r)..   RateOfActivity(y,l,'Z_Import_H2','1',r)  =l= sum(ll,RateOfActivity(y,ll,'Z_Import_H2','1',r))*YearSplit(l,y)*1.05;
 
-equation TrPA2b_FlatGasImports(y_full,l_full,r_full);
-TrPA2b_FlatGasImports(y,l,r)..   RateOfActivity(y,l,'Z_Import_Gas','1',r)  =l= sum(ll,RateOfActivity(y,ll,'Z_Import_Gas','1',r))*YearSplit(l,y)*1.05;
+*equation TrPA2b_FlatGasImports(y_full,l_full,r_full);
+*TrPA2b_FlatGasImports(y,l,r)..   RateOfActivity(y,l,'Z_Import_Gas','1',r)  =l= sum(ll,RateOfActivity(y,ll,'Z_Import_Gas','1',r))*YearSplit(l,y)*1.05;
+
+RateOfActivity.fx(y,l,'Z_ETS_Buy','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_ETS_Sell','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_Import_Gas','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_Import_H2','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_Import_Hardcoal','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_Import_LNG','1',r) = 0;
+RateOfActivity.fx(y,l,'Z_Import_Oil','1',r) = 0;
 
 
 *
@@ -836,4 +853,121 @@ ADD_Employment(r,y)..  sum((t,f),((NewCapacity(y,t,r)*EFactorManufacturing(t,y)*
                  =e= TotalJobs(r,y);
 $endif
 
+*
+* ######### Exogenous trade #############
+*
+$ifthen %switch_vertical_integration% == 0
+AllDiscountedExogenousTradeCosts.fx = 0;
+$endIf
+$ifthen %switch_vertical_integration% == 1
+* # Sum of all related trade costs
+equation ET0_SumAllDiscountedExogenousTradeCosts;
+ET0_SumAllDiscountedExogenousTradeCosts.. AllDiscountedExogenousTradeCosts =e= sum((y,r),DiscountedAnnualTotalExogenousTradeCosts(y,r)) + sum((y,f,r,exr), DiscountedNewExogenousTradeCapacityCosts(y,f,r,exr));
 
+* # Trade flow
+* Forcing the model to trade to the exogenous regions, the trade should in total be exactly as the supermodel run
+equation ET1a_ForceExogenousExport(YEAR_FULL,TIMESLICE_FULL,FUEL,EXOGENOUS_REGION_FULL);
+ET1a_ForceExogenousExport(y,l,f,exr)$(ExogenousDemand(y,l,f,exr) > 0).. sum(r$(ExogenousTradeRoute(r,exr,f)),ExogenousExport(y,l,f,r,exr)) =g= ExogenousDemand(y,l,f,exr);
+ExogenousExport.fx(y,l,f,r,exr)$(not ExogenousTradeRoute(r,exr,f)) = 0;
+ExogenousExport.fx(y,l,f,r,exr)$(ExogenousDemand(y,l,f,exr) = 0) = 0;
+equation ET1b_ForceExogenousImport(YEAR_FULL,TIMESLICE_FULL,FUEL,EXOGENOUS_REGION_FULL);
+ET1b_ForceExogenousImport(y,l,f,exr)$(ExogenousProduction(y,l,f,exr) > 0).. sum(r$(ExogenousTradeRoute(r,exr,f)),ExogenousImport(y,l,f,r,exr)) =l= ExogenousProduction(y,l,f,exr);
+ExogenousImport.fx(y,l,f,r,exr)$(not ExogenousTradeRoute(r,exr,f)) = 0;
+ExogenousImport.fx(y,l,f,r,exr)$(ExogenousProduction(y,l,f,exr) = 0) = 0;
+
+* # Trade capacity
+TotalExogenousTradeCapacity.fx(y,f,r,exr)$(not ExogenousTradeRoute(r,exr,f)) = 0;
+
+* Ensuring that enough new trade capacity is built in relation to the desired total capacity across model regions
+equation ET3a_TotalExogenousTradeCapacityStartYear(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET3a_TotalExogenousTradeCapacityStartYear(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) and TagCanFuelBeTraded(f) and YearVal(y) = %year%).. TotalExogenousTradeCapacity(y,f,r,exr) =e= ResidualExogenousTradeCapacity(r,exr,f,y);
+equation ET3b_TotalExogenousTradeCapacity(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET3b_TotalExogenousTradeCapacity(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) and TagCanFuelBeTraded(f) and YearVal(y) > %year%).. TotalExogenousTradeCapacity(y,f,r,exr) =e= TotalExogenousTradeCapacity(y-1,f,r,exr) + NewExogenousTradeCapacity(y,f,r,exr) + CommissionedExogenousTradeCapacity(r,exr,f,y);
+
+* Limit growth rate of trade capacity
+Equation ET4a_NewExogenousTradeCapacityLimitPower(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET4a_NewExogenousTradeCapacityLimitPower(y,'Power',r,exr)$(ExogenousTradeRoute(r,exr,'Power') > 0 and GrowthRateExogenousTradeCapacity(r,exr,'Power',y) > 0 and YearVal(y) > %year%).. GrowthRateExogenousTradeCapacity(r,exr,'Power',y)*YearlyDifferenceMultiplier(y)*TotalExogenousTradeCapacity(y-1,'Power',r,exr) =g= NewExogenousTradeCapacity(y,'Power',r,exr);
+Equation ET4b_NewExogenousTradeCapacityLimitNatGas(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET4b_NewExogenousTradeCapacityLimitNatGas(y,'Gas_Natural',r,exr)$(ExogenousTradeRoute(r,exr,'Gas_Natural') and GrowthRateExogenousTradeCapacity(r,exr,'Gas_Natural',y)).. 100$(not ResidualExogenousTradeCapacity(r,exr,'Gas_Natural',y)) + (GrowthRateExogenousTradeCapacity(r,exr,'Gas_Natural',y)*YearlyDifferenceMultiplier(y))*TotalExogenousTradeCapacity(y-1,'Gas_Natural',r,exr) =g= NewExogenousTradeCapacity(y,'Gas_Natural',r,exr);
+Equation ET4c_NewExogenousTradeCapacityLimitH2(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET4c_NewExogenousTradeCapacityLimitH2(y,'H2',r,exr)$(ExogenousTradeRoute(r,exr,'H2') and GrowthRateExogenousTradeCapacity(r,exr,'H2',y)).. 50$(not ResidualExogenousTradeCapacity(r,exr,'H2',y))+(GrowthRateExogenousTradeCapacity(r,exr,'H2',y)*YearlyDifferenceMultiplier(y))*TotalExogenousTradeCapacity(y-1,'H2',r,exr) =g= NewExogenousTradeCapacity(y,'H2',r,exr);
+
+* Setting remaining new exogenous trade capacity to zero
+NewExogenousTradeCapacity.fx(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) = 0 or GrowthRateExogenousTradeCapacity(r,exr,f,y) = 0) = 0;
+
+* # Trade flow limits
+* Power
+equation ET5a_ExogenousTradeCapacityPowerLinesImport(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET5a_ExogenousTradeCapacityPowerLinesImport(y,l,'Power',r,exr)$(ExogenousTradeRoute(r,exr,'Power') > 0).. (ExogenousImport(y,l,'Power',r,exr)) =l= TotalExogenousTradeCapacity(y,'Power',r,exr)*YearSplit(l,y)*31.536;
+equation ET5b_ExogenousTradeCapacityPowerLinesExport(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET5b_ExogenousTradeCapacityPowerLinesExport(y,l,'Power',r,exr)$(ExogenousTradeRoute(r,exr,'Power') > 0).. (ExogenousExport(y,l,'Power',r,exr)) =l= TotalExogenousTradeCapacity(y,'Power',r,exr)*YearSplit(l,y)*31.536;
+
+* H2
+equation ET6a_ExogenousTradeCapacityPipelinesLinesImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET6a_ExogenousTradeCapacityPipelinesLinesImport(y,l,r,exr).. ExogenousImport(y,l,'H2',r,exr) =l= TotalExogenousTradeCapacity(y,'H2',r,exr)*YearSplit(l,y);
+equation ET6b_ExogenousTradeCapacityPipelinesLinesExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET6b_ExogenousTradeCapacityPipelinesLinesExport(y,l,r,exr).. ExogenousExport(y,l,'H2',r,exr) =l= TotalExogenousTradeCapacity(y,'H2',r,exr)*YearSplit(l,y);
+
+* LH2 Trucks
+equation ET9a_ExogenousTradeCapacityTrucksImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET9a_ExogenousTradeCapacityTrucksImport(y,l,r,exr).. ExogenousImport(y,l,'LH2',r,exr) =l= TotalExogenousTradeCapacity(y,'LH2',r,exr)*YearSplit(l,y);
+equation ET9b_ExogenousTradeCapacityTrucksExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET9b_ExogenousTradeCapacityTrucksExport(y,l,r,exr).. ExogenousExport(y,l,'LH2',r,exr) =l= TotalExogenousTradeCapacity(y,'LH2',r,exr)*YearSplit(l,y);
+
+* Other
+equation ET8a_ExogenousTradeCapacityLimitNonPowerImport(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET8a_ExogenousTradeCapacityLimitNonPowerImport(y,f,r,exr)$(ExogenousTradeCapacityGrowthCosts(r,exr,f) and not sameas(f,'Power')).. sum(l,ExogenousImport(y,l,f,r,exr)) =l= TotalExogenousTradeCapacity(y,f,r,exr);
+equation ET8b_ExogenousTradeCapacityLimitNonPowerExport(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET8b_ExogenousTradeCapacityLimitNonPowerExport(y,f,r,exr)$(ExogenousTradeCapacityGrowthCosts(r,exr,f) and not sameas(f,'Power')).. sum(l,ExogenousExport(y,l,f,r,exr)) =l= TotalExogenousTradeCapacity(y,f,r,exr);
+
+* # Other trade balance
+equation ET9_ExogenousNetTradeBalance(YEAR_FULL,TIMESLICE_FULL,FUEL,REGION_FULL);
+ET9_ExogenousNetTradeBalance(y,l,f,r)$(sum(exr,ExogenousTradeRoute(r,exr,f)) and TagCanFuelBeTraded(f)).. sum(exr$(ExogenousTradeRoute(r,exr,f)), ExogenousExport(y,l,f,r,exr)*(1+ExogenousTradeLossBetweenRegions(y,f,r,exr)) - ExogenousImport(y,l,f,r,exr)) =e= ExogenousNetTrade(y,l,f,r);
+ExogenousNetTrade.fx(y,l,f,r)$(sum(exr,ExogenousTradeRoute(r,exr,f)) = 0 or TagCanFuelBeTraded(f) = 0) = 0;
+
+equation ET10_AnnualExogenousNetTradeBalance(YEAR_FULL,FUEL,REGION_FULL);
+ET10_AnnualExogenousNetTradeBalance(y,f,r)$(sum(exr,ExogenousTradeRoute(r,exr,f)) and TagCanFuelBeTraded(f)).. sum(l, (ExogenousNetTrade(y,l,f,r))) =e= ExogenousNetTradeAnnual(y,f,r);
+ExogenousNetTradeAnnual.fx(y,f,r)$(sum(exr,ExogenousTradeRoute(r,exr,f)) = 0 or TagCanFuelBeTraded(f) = 0) = 0;
+
+* # Trade costs
+* Capacity costs
+equation ET11_NewExogenousTradeCapacityCosts(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET11_NewExogenousTradeCapacityCosts(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) and ExogenousTradeCapacityGrowthCosts(r,exr,f))..  NewExogenousTradeCapacity(y,f,r,exr)*ExogenousTradeCapacityGrowthCosts(r,exr,f)*ExogenousTradeRoute(r,exr,f) =e= NewExogenousTradeCapacityCosts(y,f,r,exr);
+equation ET12_DiscountedNewExogenousTradeCapacityCosts(YEAR_FULL,FUEL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET12_DiscountedNewExogenousTradeCapacityCosts(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) and ExogenousTradeCapacityGrowthCosts(r,exr,f)).. NewExogenousTradeCapacityCosts(y,f,r,exr)/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5)) =e= DiscountedNewExogenousTradeCapacityCosts(y,f,r,exr);
+DiscountedNewExogenousTradeCapacityCosts.fx(y,f,r,exr)$(ExogenousTradeRoute(r,exr,f) = 0 or not ExogenousTradeCapacityGrowthCosts(r,exr,f)) = 0;
+
+* Trade flow costs
+equation ET13_AnnualExogenousTradeCosts(YEAR_FULL,REGION_FULL);
+ET13_AnnualExogenousTradeCosts(y,r)$(sum((f,exr),ExogenousTradeRoute(r,exr,f))).. sum((l,f,exr)$(ExogenousTradeRoute(r,exr,f)),ExogenousImport(y,l,f,r,exr) * ExogenousTradeCosts(y,f,r,exr)) + sum((l,f,exr)$(ExogenousTradeRoute(r,exr,f)),ExogenousExport(y,l,f,r,exr) * ExogenousTradeCosts(y,f,r,exr)) =e= AnnualTotalExogenousTradeCosts(y,r);
+AnnualTotalExogenousTradeCosts.fx(y,r)$(sum((f,exr),ExogenousTradeRoute(r,exr,f)) = 0) = 0;
+equation ET14_DiscountedAnnualExogenousTradeCosts(YEAR_FULL,REGION_FULL);
+ET14_DiscountedAnnualExogenousTradeCosts(y,r)..  AnnualTotalExogenousTradeCosts(y,r)/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5)) =e= DiscountedAnnualTotalExogenousTradeCosts(y,r);
+
+* # Pipeline-specific Capacity Accounting
+$ifthen.equ_hydrogen_tradecapacity %switch_hydrogen_blending_share% == 0
+
+equation ET15aa_ExogenousTradeCapacityPipelineAccountingImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15aa_ExogenousTradeCapacityPipelineAccountingImport(y,l,r,exr).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousImport(y,l,f,r,exr)) =l= TotalExogenousTradeCapacity(y,'Gas_Natural',r,exr)*YearSplit(l,y);
+equation ET15ab_ExogenousTradeCapacityPipelineAccountingExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15ab_ExogenousTradeCapacityPipelineAccountingExport(y,l,r,exr).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousExport(y,l,f,r,exr)) =l= TotalExogenousTradeCapacity(y,'Gas_Natural',r,exr)*YearSplit(l,y);
+
+$else.equ_hydrogen_tradecapacity
+
+equation ET15ba_ExogenousTradeCapacityPipelineAccountingGasFuelsImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15ba_ExogenousTradeCapacityPipelineAccountingGasFuelsImport(y,l,r,exr)$(%switch_hydrogen_blending_share%>0 and %switch_hydrogen_blending_share%<1).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousImport(y,l,f,r,exr)) + ExogenousImport(y,l,'H2_blend',r,exr)*(11.4/3.0) =l= TotalExogenousTradeCapacity(y,'gas_natural',r,exr)*YearSplit(l,y);
+equation ET15bb_ExogenousTradeCapacityPipelineAccountingGasFuelsExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15bb_ExogenousTradeCapacityPipelineAccountingGasFuelsExport(y,l,r,exr)$(%switch_hydrogen_blending_share%>0 and %switch_hydrogen_blending_share%<1).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousExport(y,l,f,r,exr)) + ExogenousExport(y,l,'H2_blend',r,exr)*(11.4/3.0) =l= TotalExogenousTradeCapacity(y,'gas_natural',r,exr)*YearSplit(l,y);
+
+equation ET15ca_ExogenousTradeCapacityPipelineAccountingH2BlendImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15ca_ExogenousTradeCapacityPipelineAccountingH2BlendImport(y,l,r,exr)$(%switch_hydrogen_blending_share%>0 and %switch_hydrogen_blending_share%<1).. ExogenousImport(y,l,'H2_blend',r,exr) =l= (%switch_hydrogen_blending_share%/((1-%switch_hydrogen_blending_share%)*(11.4/3.0))) * sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousImport(y,l,f,r,exr));
+equation ET15cb_ExogenousTradeCapacityPipelineAccountingH2BlendExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15cb_ExogenousTradeCapacityPipelineAccountingH2BlendExport(y,l,r,exr)$(%switch_hydrogen_blending_share%>0 and %switch_hydrogen_blending_share%<1).. ExogenousExport(y,l,'H2_blend',r,exr) =l= (%switch_hydrogen_blending_share%/((1-%switch_hydrogen_blending_share%)*(11.4/3.0))) * sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousExport(y,l,f,r,exr));
+
+equation ET15da_ExogenousTradeCapacityPipelineAccountingCombinedImport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15da_ExogenousTradeCapacityPipelineAccountingCombinedImport(y,l,r,exr)$(%switch_hydrogen_blending_share% = 1).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousImport(y,l,f,r,exr)) + ExogenousImport(y,l,'H2_blend',r,exr)*(11.4/3.0) =l= TotalExogenousTradeCapacity(y,'Gas_Natural',r,exr)*YearSplit(l,y);
+equation ET15db_ExogenousTradeCapacityPipelineAccountingCombinedExport(YEAR_FULL,TIMESLICE_FULL,REGION_FULL,EXOGENOUS_REGION_FULL);
+ET15db_ExogenousTradeCapacityPipelineAccountingCombinedExport(y,l,r,exr)$(%switch_hydrogen_blending_share% = 1).. sum(f$(not sameas(f,'H2_blend') and TagFuelToSubsets(f,'GasFuels')), ExogenousExport(y,l,f,r,exr)) + ExogenousExport(y,l,'H2_blend',r,exr)*(11.4/3.0) =l= TotalExogenousTradeCapacity(y,'Gas_Natural',r,exr)*YearSplit(l,y);
+
+$endif.equ_hydrogen_tradecapacity
+$endIf

--- a/genesysmod_errorcheck.gms
+++ b/genesysmod_errorcheck.gms
@@ -30,10 +30,17 @@ parameter error_TradeCostsMissingFromTradeRoute(r_full,f,rr_full);
 error_TradeCostsMissingFromTradeRoute(r,f,rr)$(sum(y,TradeRoute(r,f,y,rr)) and TagCanFuelBeTraded(f) and not sum(y,TradeCosts(r,f,y,rr))) = 1;
 if(sum((f,r,rr),error_TradeCostsMissingFromTradeRoute(r,f,rr)),abort "TradeCosts are missing from a defined TradeRoute. Please check your TradeCosts to include all defined TradeRoutes. Missing TradeCosts are listed in the parameter error_TradeCostsMissingFromTradeRoute.");
 
+$ifThen %switch_vertical_integration% == 1
+parameter error_TradeCostsMissingFromExogenousTradeRoute(r_full,f,exr_full);
+error_TradeCostsMissingFromExogenousTradeRoute(r,f,exr)$(ExogenousTradeRoute(r,exr,f) and TagCanFuelBeTraded(f) and not sum(y,ExogenousTradeCosts(y,f,r,exr))) = 1;
+if(sum((f,r,exr),error_TradeCostsMissingFromExogenousTradeRoute(r,f,exr)),abort "TradeCosts are missing from a defined ExogenousTradeRoute. Please check your EgogenousTradeCosts to include all defined ExogenousTradeRoutes. Missing ExogenousTradeCosts are listed in the parameter error_TradeCostsMissingFromExogenousTradeRoute.");
+$endIf
+
 * Check for errors in ModalSplit definitions -> if yes, then exit
 parameter error_ModalSplitByModalTypeDefinition(f,*,r_full,y_full);
 error_ModalSplitByModalTypeDefinition(f,'Error in ModalGroup',r,y)$(round(sum(mt$(TagModalTypeToModalGroups(mt,'TransportModes')),ModalSplitByFuelAndModalType(r,f,mt,y)),4)>1) = 1;
 error_ModalSplitByModalTypeDefinition(f,'Error in SubGroup',r,y)$(round(sum(mt$(TagModalTypeToModalGroups(mt,'ModalSubgroups')),ModalSplitByFuelAndModalType(r,f,mt,y)),4)>1) = 1;
+display error_ModalSplitByModalTypeDefinition;
 if(sum((f,r,y),error_ModalSplitByModalTypeDefinition(f,'Error in ModalGroup',r,y)),abort "ModalSplit is wrongly defined for a ModalGroup (e.g., MT_FRT_Road). The sum of ModalTypes cannot exceed 1. Please check your data. Problematic regions and years are listed in the parameter error_ModalSplitByModalTypeDefinition.");
 if(sum((f,r,y),error_ModalSplitByModalTypeDefinition(f,'Error in SubGroup',r,y)),abort "ModalSplit is wrongly defined for a subgroup in the ModalSplit (e.g., MT_FRT_Road_RE). The sum of ModalTypes cannot exceed 1. Please check your data. Problematic regions and years are listed in the parameter error_ModalSplitByModalTypeDefinition.");
 
@@ -44,11 +51,13 @@ error_OperationalLifeMissing(t)$(not OperationalLife(t) and not TagTechnologyToS
 $else
 error_OperationalLifeMissing(t)$(not OperationalLife(t)) = 1;
 $endif
+display error_OperationalLifeMissing;
 if(sum((t),error_OperationalLifeMissing(t)),abort "OperationalLife is missing from a Technology. Please check your OperationalLife data to account for all technologies. Missing values are listed in the parameter error_OperationalLifeMissing.");
 
 * Check for errors in CapacityFactor data -> if yes, then exit
 parameter error_CapacityFactorDataMissing(r_full,t,y_full);
 error_CapacityFactorDataMissing(r,t,y)$(not sum(l,CapacityFactor(r,t,l,y)) and AvailabilityFactor(r,t,y) and TotalAnnualMaxCapacity(r,t,y)) = 1;
+display error_CapacityFactorDataMissing;
 if(sum((r,t,y),error_CapacityFactorDataMissing(r,t,y)),abort "CapacityFactor is missing from a Technology. Please check your Hourly data file to account for all technologies. Technologies where values are missing are listed in the parameter error_CapacityFactorDataMissing.");
 
 * Check for missing entries in CapacityToActivityUnit -> if yes, then exit
@@ -62,9 +71,17 @@ error_TradeCapacityMismatch('TradeCapacity',r,f,y,rr)$(TradeCapacity(r,f,y,rr) a
 error_TradeCapacityMismatch('CommissionedTradeCapacity',r,f,y,rr)$(CommissionedTradeCapacity(r,f,y,rr) and not TradeRoute(r,f,y,rr))  = 1;
 if(sum((r,f,y,rr),error_TradeCapacityMismatch('TradeCapacity',r,f,y,rr)+error_TradeCapacityMismatch('CommissionedTradeCapacity',r,f,y,rr)),abort "TradeRoute is missing for some trade connections where a TradeCapacity has been set. Please check your TradeRoute and TradeCapacity data in Excel. Technologies where values are missing are listed in the parameter error_TradeCapacityMismatch.");
 
+$ifThen %switch_vertical_integration% == 1
+parameter error_ExogenousTradeCapacityMismatch(*,r_full,f,y_full,exr_full);
+error_ExogenousTradeCapacityMismatch('ExogenousTradeCapacity',r,f,y,exr)$(ResidualExogenousTradeCapacity(r,exr,f,y) and not ExogenousTradeRoute(r,exr,f))  = 1;
+error_ExogenousTradeCapacityMismatch('CommissionedExogenousTradeCapacity',r,f,y,exr)$(CommissionedExogenousTradeCapacity(r,exr,f,y) and not ExogenousTradeRoute(r,exr,f))  = 1;
+if(sum((r,f,y,exr),error_ExogenousTradeCapacityMismatch('ExogenousTradeCapacity',r,f,y,exr)+error_ExogenousTradeCapacityMismatch('CommissionedExogenousTradeCapacity',r,f,y,exr)),abort "ExogenousTradeRoute missing for trade connections with ResidualExogenousTradeCapacity. Check ExogenousTradeRoute & ResidualExogenousTradeCapacity data in Excel. Technologies with missing values are listed in parameter error_ExogenousTradeCapacityMismatch.");
+$endIf
+
 * Check for missing entries in AvailabilityFactor -> if yes, then exit
 parameter error_AvailabilityFactorMissing(r_full,t,y_full);
 error_AvailabilityFactorMissing(r,t,y)$(ResidualCapacity(r,t,y) and not AvailabilityFactor(r,t,y)) = 1;
+display error_AvailabilityFactorMissing;
 if(sum((r,t,y),error_AvailabilityFactorMissing(r,t,y)),display "WARNING: AvailabilityFactor is missing from a Technology. Please check your AvailabilityFactor data in Excel to account for all technologies. Technologies where values are missing are listed in the parameter error_AvailabilityFactorMissing.");
 
 
@@ -78,6 +95,11 @@ warning_TechnologyEfficiencies(r,t,m,y)$(not sum(se,TagTechnologyToSector(t,'Res
 
 parameter error_tradelines(r_full,rr_full,f);
 error_tradelines(r,rr,f)$(TradeRoute(r,f,'2018',rr)-TradeRoute(r,f,'2018',rr))=1
+
+$ifThen %switch_vertical_integration% == 1
+parameter error_Exogenoustradelines(r_full,exr_full,f);
+error_Exogenoustradelines(r,exr,f)$(ExogenousTradeRoute(r,exr,f)-ExogenousTradeRoute(r,exr,f))=1
+$endIf
 
 * If residual capacity is greater than max allowed annual capacity, set max capacity to residual capacity
 parameter ToSmallResidualCapacity;

--- a/genesysmod_gams_connect.gms
+++ b/genesysmod_gams_connect.gms
@@ -1,7 +1,11 @@
 $if %task% == "check_date" $goto check_date
+$if %task% == "load_timeseries" $goto task_time
+
 $if %task% == "load_sets" $goto task_sets
 $if %task% == "load_params" $goto task_params
-$if %task% == "load_timeseries" $goto task_time
+
+$if %task% == "load_sets_vertical_integration" $goto task_sets_vertical_integration
+$if %task% == "load_params_vertical_integration" $goto task_params_vertical_integration
 
 $label check_date
 $onEmbeddedCode Python:
@@ -430,6 +434,456 @@ $onEmbeddedCode Connect:
     duplicateRecords: "last"
 $offEmbeddedCode
 $exit
+
+$label task_sets_vertical_integration
+$onEmbeddedCode Connect:
+- ExcelReader:
+    file: %in_file%
+    symbols:
+      - name: Region_full
+        range: "Sets!A2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Technology
+        range: "Sets!B2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Storage
+        range: "Sets!C2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Fuel
+        range: "Sets!D2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Mode_of_operation
+        range: "Sets!E2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Emission
+        range: "Sets!F2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: ModalType
+        range: "Sets!G2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Sector
+        range: "Sets!H2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: Year
+        range: "Sets!I2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+        
+      - name: Exogenous_region_full
+        range: "Sets!L2"
+        type: set
+        rowDimension: 1
+        columnDimension: 0
+
+- GDXWriter:
+    file: %out_file%
+    symbols: all
+$offEmbeddedCode
+$exit
+
+$label task_params_vertical_integration
+$onEmbeddedCode Connect:
+- ExcelReader:
+    file: %in_file%
+    symbols:
+      - name: SpecifiedAnnualDemand
+        range: "Par_SpecifiedAnnualDemand!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: SpecifiedDemandDevelopment
+        range: "Par_SpecifiedDemandDevelopment!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      # Commented out in tmp
+      # - name: SpecifiedDemandProfile
+      #   range: "Par_SpecifiedDemandProfile!A2"
+      #   rowDimension: 4
+      #   columnDimension: 0
+
+      - name: ReserveMarginTagFuel
+        range: "Par_ReserveMarginTagFuel!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: EmissionsPenalty
+        range: "Par_EmissionsPenalty!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: EmissionsPenaltyTagTechnology
+        range: "Par_EmissionPenaltyTagTech!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: ReserveMargin
+        range: "Par_ReserveMargin!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: AnnualExogenousEmission
+        range: "Par_AnnualExogenousEmission!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: RegionalAnnualEmissionLimit
+        range: "Par_RegionalAnnualEmissionLimit!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: AnnualEmissionLimit
+        range: "Par_AnnualEmissionLimit!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: Readin_TradeRoute
+        range: "Par_TradeRoute!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: TradeCostFactor
+        range: "Par_TradeCostFactor!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: Readin_TradeCapacity
+        range: "Par_TradeCapacity!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: Readin_CommissionedTradeCapacity
+        range: "Par_CommissionedTradeCapacity!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: REMinProductionTarget
+        range: "Par_REMinProductionTarget!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: SelfSufficiency
+        range: "Par_SelfSufficiency!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: ProductionGrowthLimit
+        range: "Par_ProductionGrowthLimit!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: Readin_GrowthRateTradeCapacity
+        range: "Par_GrowthRateTradeCapacity!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: Readin_TradeCapacityGrowthCosts
+        range: "Par_TradeCapacityGrowthCosts!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: CapacityToActivityUnit
+        range: "Par_CapacityToActivityUnit!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: InputActivityRatio
+        range: "Par_InputActivityRatio!A2"
+        rowDimension: 5
+        columnDimension: 0
+
+      - name: OutputActivityRatio
+        range: "Par_OutputActivityRatio!A2"
+        rowDimension: 5
+        columnDimension: 0
+
+      - name: FixedCost
+        range: "Par_FixedCost!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: CapitalCost
+        range: "Par_CapitalCost!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: VariableCost
+        range: "Par_VariableCost!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: ResidualCapacity
+        range: "Par_ResidualCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: AvailabilityFactor
+        range: "Par_AvailabilityFactor!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: CapacityFactor
+        range: "Par_CapacityFactor!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: EmissionActivityRatio
+        range: "Par_EmissionActivityRatio!A2"
+        rowDimension: 5
+        columnDimension: 0
+
+      - name: EmissionContentPerFuel
+        range: "Par_EmissionContentPerFuel!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: OperationalLife
+        range: "Par_OperationalLife!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: TotalAnnualMaxCapacity
+        range: "Par_TotalAnnualMaxCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: TotalAnnualMinCapacity
+        range: "Par_TotalAnnualMinCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: NewCapacityExpansionStop
+        range: "Par_NewCapacityExpansionStop!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: Readin_TotalTechnologyModelPeriodActivityUpperLimit
+        range: "Par_ModelPeriodActivityMaxLimit!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: TotalTechnologyAnnualActivityUpperLimit
+        range: "Par_TotalAnnualMaxActivity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: TotalTechnologyAnnualActivityLowerLimit
+        range: "Par_TotalAnnualMinActivity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: ReserveMarginTagTechnology
+        range: "Par_ReserveMarginTagTechnology!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: RegionalCCSLimit
+        range: "Par_RegionalCCSLimit!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: TechnologyToStorage
+        range: "Par_TechnologyToStorage!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: TechnologyFromStorage
+        range: "Par_TechnologyFromStorage!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: StorageLevelStart
+        range: "Par_StorageLevelStart!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: MinStorageCharge
+        range: "Par_MinStorageCharge!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: OperationalLifeStorage
+        range: "Par_OperationalLifeStorage!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: CapitalCostStorage
+        range: "Par_CapitalCostStorage!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: ResidualStorageCapacity
+        range: "Par_ResidualStorageCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: Readin_ModalSplitByFuelAndModalType
+        range: "Par_ModalSplitByFuel!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: TagTechnologyToModalType
+        range: "Par_TagTechnologyToModalType!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: BaseYearProduction
+        range: "Par_BaseYearProduction!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: RegionalBaseYearProduction
+        range: "Par_RegionalBaseYearProduction!A2"
+        rowDimension: 4
+        columnDimension: 0
+
+      - name: TagTechnologyToSector
+        range: "Par_TagTechnologyToSector!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: AnnualSectoralEmissionLimit
+        range: "Par_AnnualSectoralEmissionLimit!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: TagDemandFuelToSector
+        range: "Par_TagDemandFuelToSector!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: TagElectricTechnology
+        range: "Par_TagElectricTechnology!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: TagTechnologyToSubsets
+        range: "Par_TagTechnologyToSubsets!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: TagModalTypeToModalGroups
+        range: "Par_TagModalTypeToModalGroups!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: TagFuelToSubsets
+        range: "Par_TagFuelToSubsets!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: StorageE2PRatio
+        range: "Par_StorageE2PRatio!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: TagCanFuelBeTraded
+        range: "Par_TagCanFuelBeTraded!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: ModelPeriodEmissionLimit
+        range: "Par_ModelPeriodEmissionLimit!A2"
+        rowDimension: 1
+        columnDimension: 0
+
+      - name: RegionalModelPeriodEmissionLimit
+        range: "Par_RegionalModelPeriodEmission!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: ModelPeriodExogenousEmission
+        range: "Par_ModelPeriodExogenousEmissio!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: AnnualMinNewCapacity
+        range: "Par_AnnualMinNewCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+      - name: AnnualMaxNewCapacity
+        range: "Par_AnnualMaxNewCapacity!A2"
+        rowDimension: 3
+        columnDimension: 0
+        
+      - name: DistrictHeatDemand
+        range: "Par_DistrictHeatDemand!A2"
+        rowDimension: 2
+        columnDimension: 0
+
+      - name: DistrictHeatSplit
+        range: "Par_DistrictHeatSplit!A2"
+        rowDimension: 3
+        columnDimension: 0
+        
+      - name: ExogenousDemand
+        range: "Par_ExogenousDemand!A2"
+        rowDimension: 4
+        columnDimension: 0
+        
+      - name: ExogenousProduction
+        range: "Par_ExogenousProduction!A2"
+        rowDimension: 4
+        columnDimension: 0
+        
+      - name: ExogenousTradeRoute
+        range: "Par_ExogenousTradeRoute!A2"
+        rowDimension: 3
+        columnDimension: 0
+        
+      - name: ResidualExogenousTradeCapacity
+        range: "Par_ResidualExoTradeCapacity!A2"
+        rowDimension: 4
+        columnDimension: 0
+        
+      - name: CommissionedExogenousTradeCapacity
+        range: "Par_CommissionedExoTradeCap!A2"
+        rowDimension: 4
+        columnDimension: 0
+        
+      - name: GrowthRateExogenousTradeCapacity
+        range: "Par_GrowthRateExoTradeCapacity!A2"
+        rowDimension: 4
+        columnDimension: 0
+        
+      - name: ExogenousTradeCapacityGrowthCosts
+        range: "Par_ExoTradeCapacityGrowthCosts!A2"
+        rowDimension: 3
+        columnDimension: 0
+
+- GDXWriter:
+    file: %out_file%
+    symbols: all
+    duplicateRecords: "last"
+$offEmbeddedCode
+$exit
+
 
 $label task_time
 $onEmbeddedCode Connect:

--- a/genesysmod_interpolation.gms
+++ b/genesysmod_interpolation.gms
@@ -59,6 +59,10 @@ TotalTechnologyAnnualActivityUpperLimit(r,t,y)$(TotalTechnologyAnnualActivityUpp
 
 GrowthRateTradeCapacity(r,'Power',y,rr)$(GrowthRateTradeCapacity(r,'Power',y,rr) = 0) = GrowthRateTradeCapacity(r,'Power',y-1,rr);
 
+$ifThen %switch_vertical_integration% == 1
+GrowthRateExogenousTradeCapacity(r,exr,'Power',y)$(GrowthRateExogenousTradeCapacity(r,exr,'Power',y) = 0) = GrowthRateExogenousTradeCapacity(r,exr,'Power',y-1);
+$endIf
+
 $ifthen %switch_employment_calculation% == 1
 EFactorConstruction(t,y)$(EFactorConstruction(t,y) = 0) = (EFactorConstruction(t,y-1)+EFactorConstruction(t,y+1))/2;
 EFactorOM(t,y)$(EFactorOM(t,y) = 0) = (EFactorOM(t,y-1)+EFactorOM(t,y+1))/2;

--- a/genesysmod_results.gms
+++ b/genesysmod_results.gms
@@ -29,6 +29,36 @@ output_pipeline_data('Percentage used of Pipeline network',f,'Yearly Average',r,
 parameter output_pipeline_data;
 output_pipeline_data('Percentage used of Pipeline network','Unused','Yearly Average',r,rr,y)$(TotalTradeCapacity.l(y,'Gas_Natural',r,rr)) = 1-(sum((l,f)$(TagFuelToSubsets(f,'GasFuels')),Import.l(y,l,f,rr,r))/sum(l,(TotalTradeCapacity.l(y,'Gas_Natural',r,rr)*YearSplit(l,y))));
 
+$ifThen %switch_vertical_integration% == 1
+parameter check_ExogenousImportcapacityusage;
+check_ExogenousImportcapacityusage(y,l,f,r,exr)$(ExogenousImport.l(y,l,f,r,exr) and TagFuelToSubsets(f,'GasFuels')) = (TotalExogenousTradeCapacity.l(y,f,r,exr)*YearSplit(l,y))-ExogenousImport.l(y,l,f,r,exr);
+parameter check_ExogenousExportcapacityusage;
+check_ExogenousExportcapacityusage(y,l,f,r,exr)$(ExogenousExport.l(y,l,f,r,exr) and TagFuelToSubsets(f,'GasFuels')) = (TotalExogenousTradeCapacity.l(y,f,r,exr)*YearSplit(l,y))-ExogenousExport.l(y,l,f,r,exr);
+
+parameter check_ExogenousImportcapacityfull;
+check_ExogenousImportcapacityfull(y,l,r,exr)$(sum(f$(TagFuelToSubsets(f,'GasFuels')),ExogenousImport.l(y,l,f,r,exr))=(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)) and TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1;
+parameter check_ExogenousExportcapacityfull;
+check_ExogenousExportcapacityfull(y,l,r,exr)$(sum(f$(TagFuelToSubsets(f,'GasFuels')),ExogenousExport.l(y,l,f,r,exr))=(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)) and TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1;
+
+
+parameter output_ExogenousPipeline_ImportData;
+output_ExogenousPipeline_ImportData('Percentage used of ExogenousPipeline network for import',f,l,r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr) and TagFuelToSubsets(f,'GasFuels')) = 1-(ExogenousImport.l(y,l,f,r,exr)/(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)));
+parameter output_ExogenousPipeline_ImportData;
+output_ExogenousPipeline_ImportData('Percentage used of ExogenousPipeline network for import','Unused',l,r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1-sum(f$(TagFuelToSubsets(f,'GasFuels')),(ExogenousImport.l(y,l,f,r,exr)/(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y))));
+parameter output_ExogenousPipeline_ImportData;
+output_ExogenousPipeline_ImportData('Percentage used of ExogenousPipeline network for import',f,'Yearly Average',r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr) and TagFuelToSubsets(f,'GasFuels')) = sum(l,ExogenousImport.l(y,l,f,r,exr))/sum(l,(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)));
+parameter output_ExogenousPipeline_ImportData;
+output_ExogenousPipeline_ImportData('Percentage used of ExogenousPipeline network for import','Unused','Yearly Average',r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1-(sum((l,f)$(TagFuelToSubsets(f,'GasFuels')),ExogenousImport.l(y,l,f,r,exr))/sum(l,(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y))));
+
+parameter output_ExogenousPipeline_ExportData;
+output_ExogenousPipeline_ExportData('Percentage used of ExogenousPipeline network for export',f,l,r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr) and TagFuelToSubsets(f,'GasFuels')) = 1-(ExogenousExport.l(y,l,f,r,exr)/(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)));
+parameter output_ExogenousPipeline_ExportData;
+output_ExogenousPipeline_ExportData('Percentage used of ExogenousPipeline network for export','Unused',l,r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1-sum(f$(TagFuelToSubsets(f,'GasFuels')),(ExogenousExport.l(y,l,f,r,exr)/(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y))));
+parameter output_ExogenousPipeline_ExportData;
+output_ExogenousPipeline_ExportData('Percentage used of ExogenousPipeline network for export',f,'Yearly Average',r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr) and TagFuelToSubsets(f,'GasFuels')) = sum(l,ExogenousExport.l(y,l,f,r,exr))/sum(l,(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y)));
+parameter output_ExogenousPipeline_ExportData;
+output_ExogenousPipeline_ExportData('Percentage used of ExogenousPipeline network for export','Unused','Yearly Average',r,exr,y)$(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)) = 1-(sum((l,f)$(TagFuelToSubsets(f,'GasFuels')),ExogenousExport.l(y,l,f,r,exr))/sum(l,(TotalExogenousTradeCapacity.l(y,'Gas_Natural',r,exr)*YearSplit(l,y))));
+$endIf
 
 $ifthen %switch_only_write_results% == 0
 parameter z_fuelcosts;
@@ -49,6 +79,12 @@ output_energy_balance(r,'Demand','Demand','1',f,l,'Use','PJ','%emissionPathway%_
 output_energy_balance(r,'Demand','Demand','1',f,l,'Use','billion km','%emissionPathway%_%emissionScenario%',y)$(Demand(y,l,f,r) > 0 and TagDemandFuelToSector(f,'Transportation')) = round(- Demand(y,l,f,r),4) ;
 output_energy_balance(r,'Trade','Trade','1',f,l,'Import','PJ','%emissionPathway%_%emissionScenario%',y) = round(sum(rr, Import.l(y,l,f,r,rr)),4) ;
 output_energy_balance(r,'Trade','Trade','1',f,l,'Export','PJ','%emissionPathway%_%emissionScenario%',y) = round(- sum(rr, Export.l(y,l,f,r,rr)),4) ;
+
+$ifThen %switch_vertical_integration% == 1
+output_energy_balance(r,'ExogenousTrade','ExogenousTrade','1',f,l,'ExogenousImport','PJ','%emissionPathway%_%emissionScenario%',y) = round(sum(exr, ExogenousImport.l(y,l,f,r,exr)),4) ;
+output_energy_balance(r,'ExogenousTrade','ExogenousTrade','1',f,l,'ExogenousExport','PJ','%emissionPathway%_%emissionScenario%',y) = round(- sum(exr, ExogenousExport.l(y,l,f,r,exr)),4) ;
+$endif
+
 $include genesysmod_baseyear_2020.gms
 
 parameter output_energy_balance_annual(*,*,*,*,*,*,*,*);
@@ -59,6 +95,11 @@ output_energy_balance_annual(r,'Demand','Demand',f,'Use','PJ','%emissionPathway%
 output_energy_balance_annual(r,'Demand','Demand',f,'Use','billion km','%emissionPathway%_%emissionScenario%',y)$(sum(l,Demand(y,l,f,r) > 0) and TagDemandFuelToSector(f,'Transportation')) = sum(l,output_energy_balance(r,'Demand','Demand','1',f,l,'Use','billion km','%emissionPathway%_%emissionScenario%',y)) ;
 output_energy_balance_annual(r,'Trade','Trade',f,'Import','PJ','%emissionPathway%_%emissionScenario%',y) = sum(l, output_energy_balance(r,'Trade','Trade','1',f,l,'Import','PJ','%emissionPathway%_%emissionScenario%',y)) ;
 output_energy_balance_annual(r,'Trade','Trade',f,'Export','PJ','%emissionPathway%_%emissionScenario%',y) = sum(l, output_energy_balance(r,'Trade','Trade','1',f,l,'Export','PJ','%emissionPathway%_%emissionScenario%',y)) ;
+
+$ifThen %switch_vertical_integration% == 1
+output_energy_balance_annual(r,'ExogenousTrade','ExogenousTrade',f,'ExogenousImport','PJ','%emissionPathway%_%emissionScenario%',y) = sum(l, output_energy_balance(r,'ExogenousTrade','ExogenousTrade','1',f,l,'ExogenousImport','PJ','%emissionPathway%_%emissionScenario%',y)) ;
+output_energy_balance_annual(r,'ExogenousTrade','ExogenousTrade',f,'ExogenousExport','PJ','%emissionPathway%_%emissionScenario%',y) = sum(l, output_energy_balance(r,'ExogenousTrade','ExogenousTrade','1',f,l,'ExogenousExport','PJ','%emissionPathway%_%emissionScenario%',y)) ;
+$endif
 
 parameter CapacityUsedByTechnologyEachTS, PeakCapacityByTechnology;
 CapacityUsedByTechnologyEachTS(y,l,t,r)$(AvailabilityFactor(r,t,y) <> 0 and CapacityToActivityUnit(t) <> 0 and CapacityFactor(r,t,l,y) <> 0) = RateOfProductionByTechnology(y,l,t,'Power',r)*YearSplit(l,y)/(AvailabilityFactor(r,t,y)*CapacityToActivityUnit(t)*CapacityFactor(r,t,l,y));
@@ -113,9 +154,10 @@ output_technology_costs_detailed(r,t,'none','Levelized Costs [Generation]','MEUR
 output_technology_costs_detailed(r,t,'none','Levelized Costs [Total]','MEUR/PJ',y)$(TagTechnologyToSector(t,'Power') and  not sum((f,m),InputActivityRatio(r,t,f,m,y))) = output_technology_costs_detailed(r,t,'none','Levelized Costs [Generation]','MEUR/PJ',y)+output_technology_costs_detailed(r,t,'none','Levelized Costs [Capex]','MEUR/PJ',y);
 output_technology_costs_detailed(r,t,'none','Levelized Costs [Total w/o Emissions]','MEUR/PJ',y)$(TagTechnologyToSector(t,'Power') and  not sum((f,m),InputActivityRatio(r,t,f,m,y))) = output_technology_costs_detailed(r,t,'none','Levelized Costs [Generation]','MEUR/PJ',y)+output_technology_costs_detailed(r,t,'none','Levelized Costs [Capex]','MEUR/PJ',y);
 output_technology_costs_detailed(r,t,'none','Levelized Costs [Total]','EUR/MWh',y)$(TagTechnologyToSector(t,'Power') and not sum((f,m),InputActivityRatio(r,t,f,m,y))) = output_technology_costs_detailed(r,t,'none','Levelized Costs [Total]','MEUR/PJ',y)*3.6;
+output_technology_costs_detailed(r,t,'none','Levelized Costs [Total]','EUR/MWh',y)$(TagTechnologyToSector(t,'Power') and not sum((f,m),InputActivityRatio(r,t,f,m,y))) = output_technology_costs_detailed(r,t,'none','Levelized Costs [Total]','MEUR/PJ',y)*3.6;
 output_technology_costs_detailed(r,t,'none','Levelized Costs [Total w/o Emissions]','EUR/MWh',y)$(TagTechnologyToSector(t,'Power') and not sum((f,m),InputActivityRatio(r,t,f,m,y))) = output_technology_costs_detailed(r,t,'none','Levelized Costs [Total w/o Emissions]','MEUR/PJ',y)*3.6;
 
-
+* Not to be confused with 'exogenous' trade related costs
 parameter output_exogenous_costs;
 output_exogenous_costs(r,t,'Capital Costs',y) = CapitalCost(r,t,y);
 output_exogenous_costs(r,t,'Fixed Costs',y) = FixedCost(r,t,y);
@@ -128,6 +170,21 @@ output_trade(r,rr,f,'Transmission Expansion Costs in MEUR/GW',y) = TradeCapacity
 output_trade('General','General',f,'Transmission Expansion Costs in MEUR/GW/km',y) = TradeCapacityGrowthCosts('%data_base_region%',f,'%data_base_region%');
 output_trade(r,rr,f,'Export',y) = sum(l,Export.l(y,l,f,r,rr));
 output_trade(r,rr,f,'Import',y) = sum(l,Import.l(y,l,f,r,rr));
+
+
+
+
+$ifThen %switch_vertical_integration% == 1
+output_trade(r,exr,f,'Exogenous Transmissions Capacity',y) = TotalExogenousTradeCapacity.l(y, f, r, exr);
+output_trade(r,exr,f,'Exogenous Transmission Expansion Costs in MEUR/GW',y) = ExogenousTradeCapacityGrowthCosts(r,exr,f)*ExogenousTradeRoute(r,exr,f);
+output_trade(r,exr,f,'ExogenousExport',y) = sum(l,ExogenousExport.l(y,l,f,r,exr));
+output_trade(r,exr,f,'ExogenousImport',y) = sum(l,ExogenousImport.l(y,l,f,r,exr));
+parameter output_ExogenousTrade;
+output_ExogenousTrade(r,exr,f,'ExogenousTransmissions Capacity',y) = TotalExogenousTradeCapacity.l(y, f, r, exr);
+output_ExogenousTrade(r,exr,f,'ExogenousTransmissions Expansion Costs in MEUR/GW',y) = ExogenousTradeCapacityGrowthCosts(r,exr,f)*ExogenousTradeRoute(r,exr,f);
+output_ExogenousTrade(r,exr,f,'ExogenousExport',y) = sum(l,ExogenousExport.l(y,l,f,r,exr));
+output_ExogenousTrade(r,exr,f,'ExogenousImport',y) = sum(l,ExogenousImport.l(y,l,f,r,exr));
+$endIf
 
 parameters SelfSufficiencyRate,ElectrificationRate,output_other;
 SelfSufficiencyRate(r,y) = ProductionAnnual(y,'Power',r)/(SpecifiedAnnualDemand(r,'Power',y)+UseAnnual(y,'Power',r));
@@ -215,7 +272,6 @@ output_energydemandstatistics('Import Share of Primary Energy [%]','Total',r,f,y
 output_energydemandstatistics('Import Share of Primary Energy [%]','Total','Total',f,y)$(sum((t,m,r)$(TagTechnologyToSubsets(t,'ImportTechnology')),OutputActivityRatio(r,t,f,m,y))) = (sum((t,r),ProductionByTechnologyAnnual.l(y,t,f,r))/3.6)/sum(ff,output_energydemandstatistics('Primary Energy [TWh]','Total','Total',ff,y));
 output_energydemandstatistics('Import Share of Primary Energy [%]','Total','EU27',f,y)$(sum((t,m,EU27)$(TagTechnologyToSubsets(t,'ImportTechnology')),OutputActivityRatio(EU27,t,f,m,y))) = (sum((t,EU27),ProductionByTechnologyAnnual.l(y,t,f,EU27))/3.6)/sum(ff,output_energydemandstatistics('Primary Energy [TWh]','Total','EU27',ff,y));
 
-
 $ifthen set Info
 execute_unload "%gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenario%_%info%.gdx"
 $else
@@ -229,6 +285,9 @@ output_model
 output_technology_costs_detailed
 output_exogenous_costs
 output_trade
+$ifthen %switch_vertical_integration% == 1
+output_ExogenousTrade
+$endif
 output_other
 output_energydemandstatistics
 output_fuelcosts
@@ -245,13 +304,13 @@ execute "gdxdump %gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenar
 execute "echo 'Region','Sector','Technology','Mode','Fuel','Type','Unit','PathwayScenario','Year','Value' > %resultdir%Output_AnnualProdcution_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 execute "gdxdump %gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenario%_%info%.gdx symb=output_energy_balance_annual format=csv noHeader >> %resultdir%Output_AnnualProdcution_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 
-execute "echo 'File','Region','Sector','Technology','Type','PathwayScenario','Year','Value' > %resultdir%Output_Capacity_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
+execute "echo 'Region','Sector','Technology','Type','PathwayScenario','Year','Value' > %resultdir%Output_Capacity_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 execute "gdxdump %gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenario%_%info%.gdx symb=output_capacity format=csv noHeader >> %resultdir%Output_Capacity_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 
-execute "echo 'File','Region','Sector','Emission','Technology','Type','PathwayScenario','Year','Value' > %resultdir%Output_Emission_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
+execute "echo 'Region','Sector','Emission','Technology','Type','PathwayScenario','Year','Value' > %resultdir%Output_Emission_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 execute "gdxdump %gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenario%_%info%.gdx symb=output_emissions format=csv noHeader >> %resultdir%Output_Emission_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 
-execute "echo 'File','Name','Region','Sector/Technology','Fuel','Year','Value' > %resultdir%Output_Other_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
+execute "echo 'Name','Region','Sector/Technology','Fuel','Year','Value' > %resultdir%Output_Other_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 execute "gdxdump %gdxdir%Output_%model_region%_%emissionPathway%_%emissionScenario%_%info%.gdx symb=output_other format=csv noHeader >> %resultdir%Output_Other_%model_region%_%emissionPathway%_%emissionScenario%_%info%.csv"
 
 $else

--- a/genesysmod_results_sensitivity.gms
+++ b/genesysmod_results_sensitivity.gms
@@ -53,6 +53,12 @@ $loadm DiscountedCapitalInvestment DiscountedTechnologyEmissionsPenalty Discount
 $loadm CapitalInvestment AnnualTechnologyEmissionsPenalty NewTradeCapacityCosts TradeCosts Import GeneralDiscountRate  DiscountedSalvageValue SalvageValue
 $loadm ElectrificationRate  ProductionAnnual ProductionByTechnologyAnnual  UseByTechnologyAnnual UseAnnual
 $loadm TotalCapacityAnnual TotalTradeCapacity NetTradeAnnual AnnualTechnologyEmission AnnualTotalTradeCosts
+** Exogenous Trade
+$ifThen %switch_vertical_integration% == 1
+$loadm GrowthRateExogenousTradeCapacity ExogenousTradeRoute DiscountedNewExogenousTradeCapacityCosts DiscountedAnnualTotalExogenousTradeCosts NewExogenousTradeCapacityCosts
+$loadm ExogenousTradeCosts TotalExogenousTradeCapacity ExogenousNetTradeAnnual AnnualTotalExogenousTradeCosts
+$endif
+
 ** Marginals from Equations
 equation E8_RegionalAnnualEmissionsLimit(YEAR_FULL,EMISSION,REGION_FULL);
 equation E9_AnnualEmissionsLimit(YEAR_FULL,EMISSION);
@@ -108,6 +114,22 @@ output_systemcosts('Discounted Power Costs','Transmission','Europe',y) = sum(r,(
 
 output_systemcosts('Discounted System Costs','Power','Europe_AT',y)$(output_systemcosts('Discounted System Costs','Power','Europe_AT',y) = 0) = na;
 
+$ifThen %switch_vertical_integration% == 1
+output_systemcosts('Discounted System Costs','ExogenousTrade',r,y) = DiscountedAnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),DiscountedNewExogenousTradeCapacityCosts.l(y,f,r,exr));
+output_systemcosts('Discounted System Costs','ExogenousTrade','Europe',y) = sum(r,output_systemcosts('Discounted System Costs','ExogenousTrade',r,y));
+
+output_systemcosts('Discounted System Cost Split','ExogenousTrade',r,y) = DiscountedAnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),DiscountedNewExogenousTradeCapacityCosts.l(y,f,r,exr));
+output_systemcosts('Discounted System Cost Split','ExogenousTrade','Europe',y) = sum(r,DiscountedAnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),DiscountedNewExogenousTradeCapacityCosts.l(y,f,r,exr)));
+
+output_systemcosts('Discounted Power Costs','ExogenousTrade',r,y) = sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr)*ExogenousTradeCosts(y,'Power',r,exr))/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5))+sum((exr),DiscountedNewExogenousTradeCapacityCosts.l(y,'Power',r,exr));
+output_systemcosts('Discounted Power Costs','ExogenousTrade','Europe',y) = sum(r,sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr)*ExogenousTradeCosts(y,'Power',r,exr))/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5))+sum((exr),DiscountedNewExogenousTradeCapacityCosts.l(y,'Power',r,exr)));
+
+output_systemcosts('Discounted Power Costs','ExogenousTransmission',r,y) = (sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr))/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5)))
++sum(exr,DiscountedNewExogenousTradeCapacityCosts.l(y,'Power',r,exr));
+output_systemcosts('Discounted Power Costs','ExogenousTransmission','Europe',y) = sum(r,(sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr))/((1+GeneralDiscountRate(r))**(YearVal(y)-smin(yy, YearVal(yy))+0.5)))
++sum(exr,DiscountedNewExogenousTradeCapacityCosts.l(y,'Power',r,exr)));
+$endif
+
 * UNDISCOUNTED
 
 output_systemcosts('Nominal System Costs',se,r,y) = sum((t)$(TagTechnologyToSector(t,se)),CapitalInvestment.l(y,t,r)
@@ -145,14 +167,36 @@ output_systemcosts('Nominal Power Costs','Transmission',r,y) = (sum((l,rr)$(Trad
 output_systemcosts('Nominal Power Costs','Transmission','Europe',y) = sum(r,(sum((l,rr)$(TradeRoute(r,'Power',y,rr)),Import.l(y,l,'Power',r,rr) * TradeCosts('Power',r,rr)))
 +sum(rr,NewTradeCapacityCosts.l(y,'Power',r,rr)));
 
+$ifThen %switch_vertical_integration% == 0
 output_systemcosts('Nominal System Costs','Total',r,y) = sum(se,output_systemcosts('Nominal System Costs',se,r,y))+output_systemcosts('Nominal System Costs','Trade',r,y);
 output_systemcosts('Nominal System Costs','Total','Europe',y) = sum(r, output_systemcosts('Nominal System Costs','Total',r,y))+output_systemcosts('Nominal System Costs','Trade','Europe',y);
 
 output_systemcosts('Discounted System Costs','Total',r,y) = sum(se,output_systemcosts('Discounted System Costs',se,r,y))+output_systemcosts('Discounted System Costs','Trade',r,y);
 output_systemcosts('Discounted System Costs','Total','Europe',y) = sum(r, output_systemcosts('Discounted System Costs','Total',r,y))+output_systemcosts('Discounted System Costs','Trade','Europe',y);
-
+$endif
 output_systemcosts('Nominal System Costs','Industry','Europe_AT',y)$(output_systemcosts('Nominal System Costs','Industry','Europe_AT',y) = 0) = na;
 
+$ifThen %switch_vertical_integration% == 1
+output_systemcosts('Nominal System Costs','ExogenousTrade',r,y) = AnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),NewExogenousTradeCapacityCosts.l(y,f,r,exr));
+output_systemcosts('Nominal System Costs','ExogenousTrade','Europe',y) = sum(r,output_systemcosts('Nominal System Costs','ExogenousTrade',r,y));
+
+output_systemcosts('Nominal System Cost Split','ExogenousTrade',r,y) = AnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),NewExogenousTradeCapacityCosts.l(y,f,r,exr));
+output_systemcosts('Nominal System Cost Split','ExogenousTrade','Europe',y) = sum(r,AnnualTotalExogenousTradeCosts.l(y,r)+sum((f,exr),NewExogenousTradeCapacityCosts.l(y,f,r,exr)));
+
+output_systemcosts('Nominal Power Costs','ExogenousTrade',r,y) = sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr)) + sum((exr),NewExogenousTradeCapacityCosts.l(y,'Power',r,exr));
+output_systemcosts('Nominal Power Costs','ExogenousTrade','Europe',y) = sum(r,sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr)) + sum((rr),NewExogenousTradeCapacityCosts.l(y,'Power',r,exr)));
+
+output_systemcosts('Nominal Power Costs','ExogenousTransmission',r,y) = (sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr)))
++sum(exr,NewExogenousTradeCapacityCosts.l(y,'Power',r,exr));
+output_systemcosts('Nominal Power Costs','ExogenousTransmission','Europe',y) = sum(r,(sum((l,exr)$(ExogenousTradeRoute(r,exr,'Power')),ExogenousImport.l(y,l,'Power',r,exr) * ExogenousTradeCosts(y,'Power',r,exr)))
++sum(exr,NewExogenousTradeCapacityCosts.l(y,'Power',r,exr)));
+
+output_systemcosts('Nominal System Costs','Total',r,y) = sum(se,output_systemcosts('Nominal System Costs',se,r,y))+output_systemcosts('Nominal System Costs','Trade',r,y)+output_systemcosts('Nominal System Costs','ExogenousTrade',r,y);
+output_systemcosts('Nominal System Costs','Total','Europe',y) = sum(r, output_systemcosts('Nominal System Costs','Total',r,y))+output_systemcosts('Nominal System Costs','Trade','Europe',y)+output_systemcosts('Nominal System Costs','ExogenousTrade','Europe',y);
+
+output_systemcosts('Discounted System Costs','Total',r,y) = sum(se,output_systemcosts('Discounted System Costs',se,r,y))+output_systemcosts('Discounted System Costs','Trade',r,y)+output_systemcosts('Discounted System Costs','ExogenousTrade',r,y);
+output_systemcosts('Discounted System Costs','Total','Europe',y) = sum(r, output_systemcosts('Discounted System Costs','Total',r,y))+output_systemcosts('Discounted System Costs','Trade','Europe',y)+output_systemcosts('Discounted System Costs','ExogenousTrade','Europe',y);
+$endif
 
 * -------
 * Electrification rates and volumes (%, TWh of electricity consumed [=production without storages])
@@ -405,8 +449,23 @@ parameter output_interconnection;
 output_interconnection('Transmission Capacity [GW]',r,y) = sum(rr,TotalTradeCapacity.l(y,'Power',r,rr));
 output_interconnection('Net Trade Volumes [TWh]',r,y) = NetTradeAnnual.l(y,'Power',r)/3.6;
 output_interconnection('Absolute Import Volume [TWh]',r,y) = sum((l,rr), Import.l(y,l,'Power',r,rr));
-output_interconnection('Import Dependency [%]',r,y) = (-1)*min(0,NetTradeAnnual.l(y,'Power',r))/(UseAnnual.l(y,'Power',r)-sum(StorageDummies,UseByTechnologyAnnual.l(y,StorageDummies,'Power',r))+SpecifiedAnnualDemand(r,'Power',y));
 output_interconnection('Transmission Capacity [GW]','Europe_AT',y)$(output_interconnection('Transmission Capacity [GW]','Europe_AT',y) = 0) = na;
+
+$ifThen %switch_vertical_integration% == 0
+output_interconnection('Import Dependency [%]',r,y) = (-1)*min(0,NetTradeAnnual.l(y,'Power',r))/(UseAnnual.l(y,'Power',r)-sum(StorageDummies,UseByTechnologyAnnual.l(y,StorageDummies,'Power',r))+SpecifiedAnnualDemand(r,'Power',y));
+$endif
+
+$ifThen %switch_vertical_integration% == 1
+output_interconnection('Import Dependency [%]',r,y) = (-1)*min(0,NetTradeAnnual.l(y,'Power',r))/(UseAnnual.l(y,'Power',r)-sum(StorageDummies,UseByTechnologyAnnual.l(y,StorageDummies,'Power',r))+SpecifiedAnnualDemand(r,'Power',y));
+
+parameter output_ExogenousInterconnection;
+output_ExogenousInterconnection('ExogenousTransmission Capacity [GW]',r,y) = sum(exr,TotalExogenousTradeCapacity.l(y,'Power',r,exr));
+output_ExogenousInterconnection('Net ExogenousTrade Volumes [TWh]',r,y) = ExogenousNetTradeAnnual.l(y,'Power',r)/3.6;
+output_ExogenousInterconnection('Absolute ExogenousImport Volume [TWh]',r,y) = sum((l,exr), ExogenousImport.l(y,l,'Power',r,exr));
+output_ExogenousInterconnection('Absolute ExogenousExport Volume [TWh]',r,y) = sum((l,exr), ExogenousExport.l(y,l,'Power',r,exr));
+output_ExogenousInterconnection('ExogenousImport Dependency [%]',r,y) = (-1)*min(0,ExogenousNetTradeAnnual.l(y,'Power',r))/(UseAnnual.l(y,'Power',r)-sum(StorageDummies,UseByTechnologyAnnual.l(y,StorageDummies,'Power',r))+SpecifiedAnnualDemand(r,'Power',y));
+output_ExogenousInterconnection('ExogenousTransmission Capacity [GW]','Europe_AT',y)$(output_ExogenousInterconnection('ExogenousTransmission Capacity [GW]','Europe_AT',y) = 0) = na;
+$endif
 
 * -------
 * Emissions

--- a/genesysmod_scenariodata_sweden.gms
+++ b/genesysmod_scenariodata_sweden.gms
@@ -1,0 +1,79 @@
+AvailabilityFactor(r,'X_DAC_HT',y) = 0;
+AvailabilityFactor(r,'X_DAC_LT',y) = 0;
+
+
+parameter warning_TotalAnnualMinCapacityTooHigh;
+warning_TotalAnnualMinCapacityTooHigh(r,t,y)$(TotalAnnualMaxCapacity(r,t,y)<TotalAnnualMinCapacity(r,t,'2025')) = 1;
+
+TotalAnnualMaxCapacity(r,t,y)$(TotalAnnualMaxCapacity(r,t,y)<TotalAnnualMinCapacity(r,t,'2025')) = TotalAnnualMinCapacity(r,t,'2025');
+
+* Limit capacity expansion in 2025 to only actually (historically) installed capacities
+NewCapacity.up('2025',t,r)$(TagTechnologyToSubsets(t,'PowerSupply') and not TotalAnnualMinCapacity(r,t,'2025') and not AnnualMinNewCapacity(r,t,'2025')) = TotalAnnualMinCapacity(r,t,'2025');
+
+ProductionByTechnologyAnnual.up(y,'CHP_WasteToEnergy','Heat_District',r) = RegionalBaseYearProduction(r,'CHP_WasteToEnergy','Heat_District','2018');
+OutputActivityRatio(r,'CHP_WasteToEnergy',f,'1',y) = 0;
+
+ProductionByTechnologyAnnual.up(y,'HD_Heatpump_ExcessHeat','Heat_District',r)$(YearVal(y)>2018) = SpecifiedAnnualDemand(r,'Heat_District',y)*0.08;
+
+ProductionByTechnologyAnnual.up(y,'HLI_Geothermal','Heat_Low_Industrial',r) = SpecifiedAnnualDemand(r,'Heat_Low_Industrial',y)*0.25;
+
+
+$ifthen %emissionPathway% == REPowerEU_Sweden
+
+ProductionByTechnologyAnnual.up(y,'HHI_Scrap_EAF','Heat_High_Industrial',r) = SpecifiedAnnualDemand(r,'Heat_High_Industrial',y)*0.65;
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_PSNG_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.002*(YearVal(y)-2025);
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_FRT_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.002*(YearVal(y)-2025);
+
+$elseif %emissionPathway% == NECPEssentials_Sweden
+
+
+ProductionByTechnologyAnnual.up(y,'HHI_Scrap_EAF','Heat_High_Industrial',r) = SpecifiedAnnualDemand(r,'Heat_High_Industrial',y)*0.6;
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_PSNG_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.00175*(YearVal(y)-2025);
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_FRT_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.00175*(YearVal(y)-2025);
+
+$elseif %emissionPathway% == Green_Sweden
+
+ProductionByTechnologyAnnual.up(y,'HHI_Scrap_EAF','Heat_High_Industrial',r) = SpecifiedAnnualDemand(r,'Heat_High_Industrial',y)*0.75;
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_PSNG_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.00225*(YearVal(y)-2025);
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_FRT_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.00225*(YearVal(y)-2025);
+
+$elseif %emissionPathway% == Trinity_Sweden
+ProductionByTechnologyAnnual.up(y,'HHI_Scrap_EAF','Heat_High_Industrial',r) = SpecifiedAnnualDemand(r,'Heat_High_Industrial',y)*0.5;
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_PSNG_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.001*(YearVal(y)-2025);
+ModalSplitByFuelAndModalType(r,f,mt,y)$(sameas(mt,'MT_FRT_ROAD') and YearVal(y)>2025 and ModalSplitByFuelAndModalType(r,f,mt,y)) = ModalSplitByFuelAndModalType(r,f,mt,'2025')-0.001*(YearVal(y)-2025);
+
+$endif
+
+equation DistrictHeatProductionAnnualLowerLimit(r_full, FUEL, y_full);
+DistrictHeatProductionAnnualLowerLimit(r,f,y)$(sameas(f,'Heat_District') and DistrictHeatDemand(r,y)).. sum(t,ProductionByTechnologyAnnual(y,t,'Heat_District',r)) =g= DistrictHeatDemand(r,y)*InputActivityRatio(r,'X_Convert_HD',f,'1',y)*0.95;
+ 
+equation DistrictHeatProductionAnnualUpperLimit(r_full, FUEL, y_full);
+DistrictHeatProductionAnnualUpperLimit(r,f,y)$(sameas(f,'Heat_District') and DistrictHeatDemand(r,y)).. sum(t,ProductionByTechnologyAnnual(y,t,'Heat_District',r)) =l= DistrictHeatDemand(r,y)*InputActivityRatio(r,'X_Convert_HD',f,'1',y)*1.05;
+ 
+equation DistrictHeatProductionSplit(r_full, Sector, y_full);
+DistrictHeatProductionSplit(r,se,y)$(DistrictHeatSplit(r,se,y)).. sum((f,t)$(TagDemandFuelToSector(f,se) and TagTechnologyToSubsets(t,'Convert')),ProductionByTechnologyAnnual(y,t,f,r)) =g= DistrictHeatDemand(r,y)*DistrictHeatSplit(r,se,y);
+
+* National limits to annual new capacities
+parameter NationalAnnualMaxNewCapacity(TECHNOLOGY,YEAR_FULL);
+NationalAnnualMaxNewCapacity('HB_Biomass','2025') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2030') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2035') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2040') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2045') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2050') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2055') = 6;
+NationalAnnualMaxNewCapacity('HB_Biomass','2060') = 6;
+NationalAnnualMaxNewCapacity('P_Nuclear','2035') = 2.5;
+NationalAnnualMaxNewCapacity('P_Nuclear','2040') = 5;
+NationalAnnualMaxNewCapacity('P_Nuclear','2045') = 5;
+
+equation NationalAnnualMaxNewCapacityConstraint(YEAR_FULL,TECHNOLOGY);
+NationalAnnualMaxNewCapacityConstraint(y,t)$(NationalAnnualMaxNewCapacity(t,y) <> 0).. sum(r,NewCapacity(y,t,r)) =l= NationalAnnualMaxNewCapacity(t,y);
+
+parameter NationalAnnualMinNewCapacity(TECHNOLOGY,YEAR_FULL);
+NationalAnnualMinNewCapacity('P_Nuclear','2035') = 2.5;
+NationalAnnualMinNewCapacity('P_Nuclear','2040') = 5;
+NationalAnnualMinNewCapacity('P_Nuclear','2045') = 5;
+
+equation NationalAnnualMinNewCapacityConstraint(YEAR_FULL,TECHNOLOGY);
+NationalAnnualMinNewCapacityConstraint(y,t)$(NationalAnnualMinNewCapacity(t,y) <> 0).. sum(r,NewCapacity(y,t,r)) =g= NationalAnnualMinNewCapacity(t,y);


### PR DESCRIPTION
# 📌 Pull Request Summary

Adding the vertical integration feature. The feature is found as a switch in the main "genesysmod.gms" script for running the model. 

The changes should be accepted as a branch and not be directly pulled into the main branch. 

## 🔗 Related Issue(s)

This allows for vertical integration of a macro-level model and a submodel, e.g. Continent --> Country given that the data needed for the different models are provided. 

## 🛠️ Changes Introduced

- Describe the main changes made
- Highlight any new files, modules, or functions
- Note any external dependencies or migrations

Changes have been made to: "additional_results", "bounds", "dec", "equ", "errorcheck", "gams_connect", "interpolation", "results_sensitivity", "results" as well as the addition of "dataload_long_vertical_integration" and "scenariodata_sweden". 

When switched on the vertical integration feature reads in additional parameters representing the trade flows between regions in the macro-level model and sets these as constraints for the solution of the submodel. In order to use this should the vertical integration tool found in GENeSYS_MOD.tools be used. The tool allows for extraction of trade flows from the macro-level model and converts it into input used in the vertical integration feature found here. 

## 📋 Checklist

- [ x] Code follows project conventions
- [ x] Tests have been added/updated (if needed)
- [ x] Documentation has been updated (if applicable)
- [ x] Relevant issues linked
- [ x] Reviewers assigned
